### PR TITLE
Add results findStep helper

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -64,28 +64,23 @@ export default defineConfig([
   steps.resolvePackage({ name: "vanilla-ts" }),
   steps.resolvePublishedVersion({
     packageName: ({ results }) =>
-      results.findLast(({ step }) => step === "resolvePackage")!.value
-        .packageName,
+      results.findStep("resolvePackage").packageName,
   }),
   steps.calculateNextSemver({
     currentVersion: ({ results }) =>
-      results.findLast(({ step }) => step === "resolvePublishedVersion")!.value
-        .currentVersion,
+      results.findStep("resolvePublishedVersion").currentVersion,
     level: "patch",
   }),
   steps.writePackageVersion({
     packageJsonPath: ({ results }) =>
-      results.findLast(({ step }) => step === "resolvePackage")!.value
-        .packageJsonPath,
+      results.findStep("resolvePackage").packageJsonPath,
     version: ({ results }) =>
-      results.findLast(({ step }) => step === "calculateNextSemver")!.value
-        .nextVersion,
+      results.findStep("calculateNextSemver").nextVersion,
   }),
   steps.runCommand("pnpm build"),
   steps.stageFiles({
     paths: ({ results }) => [
-      results.findLast(({ step }) => step === "resolvePackage")!.value
-        .packageJsonPath,
+      results.findStep("resolvePackage").packageJsonPath,
     ],
   }),
   steps.commit({ message: "Release vanilla-ts" }),

--- a/packages/core/src/flow/runFlow.ts
+++ b/packages/core/src/flow/runFlow.ts
@@ -1,6 +1,7 @@
 import type {
   RlseContext,
   RlseFlowStep,
+  RlseResults,
   RlseStep,
   RlseStepResult,
 } from "./types";
@@ -16,15 +17,35 @@ const normalizeStep = (step: RlseFlowStep): RlseStep => {
   return step;
 };
 
+const createResults = (results: RlseStepResult[] = []): RlseResults => {
+  Object.defineProperty(results, "findStep", {
+    value(step: string) {
+      const result = results.findLast((item) => item.step === step);
+
+      if (!result) {
+        throw new Error(`${step} result was not found`);
+      }
+
+      return result.value;
+    },
+  });
+
+  return results as RlseResults;
+};
+
+type RlseInitialContext = Partial<Omit<RlseContext, "results">> & {
+  results?: RlseStepResult[];
+};
+
 export const runFlow = async (
   flow: RlseFlowStep[],
-  initialContext?: Partial<RlseContext>,
+  initialContext?: RlseInitialContext,
 ) => {
   const context: RlseContext = {
     cwd: process.cwd(),
     dryRun: false,
     ...initialContext,
-    results: [...(initialContext?.results ?? [])],
+    results: createResults([...(initialContext?.results ?? [])]),
   };
   const completedSteps: { step: RlseStep; result: RlseStepResult }[] = [];
 

--- a/packages/core/src/flow/types.ts
+++ b/packages/core/src/flow/types.ts
@@ -1,7 +1,36 @@
+import type { PackageJson } from "../steps/package/utils";
+import type { ReleaseLevel } from "../types/RlseConfig";
+
 export type RlseContext = {
   cwd: string;
   dryRun: boolean;
-  results: RlseStepResult[];
+  results: RlseResults;
+};
+
+export interface RlseResults extends Array<RlseStepResult> {
+  findStep<Step extends keyof RlseKnownStepResults>(
+    step: Step,
+  ): RlseKnownStepResults[Step];
+  findStep<T = Record<string, unknown>>(step: string): T;
+}
+
+export type RlseKnownStepResults = {
+  resolvePackage: {
+    packageJsonPath: string;
+    packageJson: PackageJson;
+    packageName: string;
+  };
+  resolvePublishedVersion: {
+    packageName: string;
+    currentVersion: string;
+    source: "registry" | "fallback";
+  };
+  calculateNextSemver: {
+    currentVersion: string;
+    nextVersion: string;
+    level?: ReleaseLevel;
+    pre: boolean;
+  };
 };
 
 export type RlseStepResult = {

--- a/packages/core/src/flow/types.ts
+++ b/packages/core/src/flow/types.ts
@@ -11,7 +11,7 @@ export interface RlseResults extends Array<RlseStepResult> {
   findStep<Step extends keyof RlseKnownStepResults>(
     step: Step,
   ): RlseKnownStepResults[Step];
-  findStep<T = Record<string, unknown>>(step: string): T;
+  findStep<T = unknown>(step: string): T;
 }
 
 export type RlseKnownStepResults = {

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -4,6 +4,8 @@ import { runFlow } from "./flow/runFlow";
 import type {
   RlseContext,
   RlseFlowStep,
+  RlseKnownStepResults,
+  RlseResults,
   RlseStep,
   RlseStepResult,
 } from "./flow/types";
@@ -11,4 +13,11 @@ import * as presets from "./presets/index";
 import * as steps from "./steps/index";
 
 export { defineConfig, presets, runFlow, steps, z };
-export type { RlseContext, RlseFlowStep, RlseStep, RlseStepResult };
+export type {
+  RlseContext,
+  RlseFlowStep,
+  RlseKnownStepResults,
+  RlseResults,
+  RlseStep,
+  RlseStepResult,
+};

--- a/packages/core/test/config-version.test.mjs
+++ b/packages/core/test/config-version.test.mjs
@@ -219,3 +219,31 @@ test("collects flow step results", async () => {
     { step: "second", value: { previousStep: "first" } },
   ]);
 });
+
+test("finds latest flow step result value", async () => {
+  const { runFlow } = await import(publicApiPath);
+
+  const context = await runFlow([
+    {
+      name: "package",
+      run: () => ({ packageName: "first" }),
+    },
+    {
+      name: "package",
+      run: () => ({ packageName: "latest" }),
+    },
+  ]);
+
+  assert.equal(context.results.findStep("package").packageName, "latest");
+});
+
+test("throws when flow step result is missing", async () => {
+  const { runFlow } = await import(publicApiPath);
+
+  const context = await runFlow([]);
+
+  assert.throws(
+    () => context.results.findStep("missing"),
+    /missing result was not found/,
+  );
+});


### PR DESCRIPTION
## Summary
- Add `results.findStep(stepName)` to fetch the latest value for a completed flow step.
- Add typed known-step result mappings for built-in release steps.
- Update README examples and tests to cover latest-match and missing-step behavior.

## Tests
- `pnpm -C packages/core test`
- `pnpm -C packages/core check`