### PR TITLE
Rename npm package to rlse.ts

### DIFF
--- a/docs/src/components/layouts/Header/Header.tsx
+++ b/docs/src/components/layouts/Header/Header.tsx
@@ -17,7 +17,7 @@ export const Header = () => {
           <GithubIcon />
         </a>
         <a
-          href="https://www.npmjs.com/package/@takuma-ru/rlse"
+          href="https://www.npmjs.com/package/release.ts"
           target="_blank"
           rel="noreferrer"
         >

--- a/docs/src/config.ts
+++ b/docs/src/config.ts
@@ -4,6 +4,6 @@ type Config = {
 };
 
 export const config = {
-  packageName: "@takuma-ru/rlse",
+  packageName: "release.ts",
   registry: "npm",
 } as const satisfies Config;

--- a/docs/src/index.tsx
+++ b/docs/src/index.tsx
@@ -10,7 +10,7 @@ app.get("/", (c) => {
       <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <title>@takuma-ru/rlse</title>
+        <title>release.ts</title>
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link
           rel="preconnect"

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,4 +1,4 @@
-# @takuma-ru/rlse
+# release.ts
 
 TypeScript release workflow runner with reusable safety steps.
 
@@ -18,7 +18,7 @@ GitHub Releases.
 ### 1. Install
 
 ```shell
-npm install @takuma-ru/rlse
+npm install release.ts
 ```
 
 ### 2. Add script to package.json
@@ -51,7 +51,7 @@ In addition to ts, the following file formats are supported.
 ### Example
 
 ```ts filename=rlse.config.ts
-import { defineConfig, presets } from "@takuma-ru/rlse";
+import { defineConfig, presets } from "release.ts";
 
 export default defineConfig(
   presets.npmRelease({
@@ -70,7 +70,7 @@ around it when your release needs extra side effects, such as GitHub Releases or
 changelog updates.
 
 ```ts filename=rlse.config.ts
-import { defineConfig, presets, steps } from "@takuma-ru/rlse";
+import { defineConfig, presets, steps } from "release.ts";
 
 export default defineConfig([
   steps.checkCleanWorkingTree(),
@@ -87,7 +87,7 @@ export default defineConfig([
 Use primitives directly only when you need full control over every side effect.
 
 ```ts filename=rlse.config.ts
-import { defineConfig, steps } from "@takuma-ru/rlse";
+import { defineConfig, steps } from "release.ts";
 
 export default defineConfig([
   steps.resolvePackage({ name: "vanilla-ts" }),
@@ -210,7 +210,7 @@ Custom steps can be added with `(context) => { ... }`.
 CLI arguments can be declared with Zod in config and used when building the flow.
 
 ```ts filename=rlse.config.ts
-import { defineConfig, presets, z } from "@takuma-ru/rlse";
+import { defineConfig, presets, z } from "release.ts";
 
 export default defineConfig({
   args: z.object({

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "release.ts",
-  "version": "0.0.2",
+  "version": "0.0.0",
   "private": false,
   "description": "TypeScript release workflow runner with reusable safety steps.",
   "homepage": "https://github.com/takuma-ru/rlse",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -63,9 +63,9 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
-    "release.ts": "workspace:*",
     "@types/node": "^20.14.2",
     "@types/semver": "^7.5.8",
+    "release.ts": "workspace:*",
     "tsup": "^8.1.0",
     "typescript": "^5.2.2"
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@takuma-ru/rlse",
+  "name": "release.ts",
   "version": "0.0.2",
   "private": false,
   "description": "TypeScript release workflow runner with reusable safety steps.",
@@ -63,7 +63,7 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
-    "@takuma-ru/rlse": "workspace:*",
+    "release.ts": "workspace:*",
     "@types/node": "^20.14.2",
     "@types/semver": "^7.5.8",
     "tsup": "^8.1.0",

--- a/packages/core/rlse.config.ts
+++ b/packages/core/rlse.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
         name: "github-actions[bot]",
         email: "41898282+github-actions[bot]@users.noreply.github.com",
       },
-      resolvePackage: { name: "@takuma-ru/rlse" },
+      resolvePackage: { name: "release.ts" },
       calculateNextSemver: { level: args.level },
       runCommand: "pnpm build",
     }),

--- a/packages/core/src/config/loadRlseConfig.ts
+++ b/packages/core/src/config/loadRlseConfig.ts
@@ -87,7 +87,9 @@ const importTypeScriptConfig = async (filePath: string) => {
         noUnusedParameters: true,
         noFallthroughCasesInSwitch: true,
         paths: {
-          "release.ts": [resolve(cwd(), "node_modules/release.ts/dist/main.js")],
+          "release.ts": [
+            resolve(cwd(), "node_modules/release.ts/dist/main.js"),
+          ],
         },
       },
       exclude: ["node_modules"],

--- a/packages/core/src/config/loadRlseConfig.ts
+++ b/packages/core/src/config/loadRlseConfig.ts
@@ -87,9 +87,7 @@ const importTypeScriptConfig = async (filePath: string) => {
         noUnusedParameters: true,
         noFallthroughCasesInSwitch: true,
         paths: {
-          "@takuma-ru/rlse": [
-            resolve(cwd(), "node_modules/@takuma-ru/rlse/dist/main.js"),
-          ],
+          "release.ts": [resolve(cwd(), "node_modules/release.ts/dist/main.js")],
         },
       },
       exclude: ["node_modules"],

--- a/playgrounds/vanilla-ts/package.json
+++ b/playgrounds/vanilla-ts/package.json
@@ -16,7 +16,7 @@
     "rlse:test": "pnpm link:core && pnpm exec rlse"
   },
   "devDependencies": {
-    "@takuma-ru/rlse": "workspace:*",
+    "release.ts": "workspace:*",
     "ts-node": "^10.9.2",
     "typescript": "^5.2.2",
     "vite": "^5.3.5"

--- a/playgrounds/vanilla-ts/rlse.config.ts
+++ b/playgrounds/vanilla-ts/rlse.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, presets, z } from "@takuma-ru/rlse";
+import { defineConfig, presets, z } from "release.ts";
 
 export default defineConfig({
   args: z.object({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,15 +100,15 @@ importers:
         specifier: ^3.23.8
         version: 3.23.8
     devDependencies:
-      '@takuma-ru/rlse':
-        specifier: workspace:*
-        version: 'link:'
       '@types/node':
         specifier: ^20.14.2
         version: 20.14.7
       '@types/semver':
         specifier: ^7.5.8
         version: 7.5.8
+      release.ts:
+        specifier: workspace:*
+        version: 'link:'
       tsup:
         specifier: ^8.1.0
         version: 8.1.0(postcss@8.4.40)(ts-node@10.9.2(@types/node@20.14.7)(typescript@5.5.2))(typescript@5.5.2)
@@ -118,7 +118,7 @@ importers:
 
   playgrounds/vanilla-ts:
     devDependencies:
-      '@takuma-ru/rlse':
+      release.ts:
         specifier: workspace:*
         version: link:../../packages/core
       ts-node:


### PR DESCRIPTION
## Summary
- Rename the published package from `@takuma-ru/rlse` to `rlse.ts`.
- Update workspace dependencies, lockfile entries, docs examples, npm links, and release config references.
- Reset the renamed package version to `0.0.0` and normalize npm manifest fields.

## Verification
- `pnpm p:core check`
- `pnpm -C packages/core build`
- `npm pack --dry-run`
- Published `rlse.ts@0.0.0` manually for the initial release