### PR TITLE
Rename npm package to rlse.ts

### DIFF
--- a/docs/src/components/layouts/Header/Header.tsx
+++ b/docs/src/components/layouts/Header/Header.tsx
@@ -17,7 +17,7 @@ export const Header = () => {
           <GithubIcon />
         </a>
         <a
-          href="https://www.npmjs.com/package/release.ts"
+          href="https://www.npmjs.com/package/rlse.ts"
           target="_blank"
           rel="noreferrer"
         >

--- a/docs/src/config.ts
+++ b/docs/src/config.ts
@@ -4,6 +4,6 @@ type Config = {
 };
 
 export const config = {
-  packageName: "release.ts",
+  packageName: "rlse.ts",
   registry: "npm",
 } as const satisfies Config;

--- a/docs/src/index.tsx
+++ b/docs/src/index.tsx
@@ -10,7 +10,7 @@ app.get("/", (c) => {
       <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <title>release.ts</title>
+        <title>rlse.ts</title>
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link
           rel="preconnect"

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,4 +1,4 @@
-# release.ts
+# rlse.ts
 
 TypeScript release workflow runner with reusable safety steps.
 
@@ -18,7 +18,7 @@ GitHub Releases.
 ### 1. Install
 
 ```shell
-npm install release.ts
+npm install rlse.ts
 ```
 
 ### 2. Add script to package.json
@@ -51,7 +51,7 @@ In addition to ts, the following file formats are supported.
 ### Example
 
 ```ts filename=rlse.config.ts
-import { defineConfig, presets } from "release.ts";
+import { defineConfig, presets } from "rlse.ts";
 
 export default defineConfig(
   presets.npmRelease({
@@ -70,7 +70,7 @@ around it when your release needs extra side effects, such as GitHub Releases or
 changelog updates.
 
 ```ts filename=rlse.config.ts
-import { defineConfig, presets, steps } from "release.ts";
+import { defineConfig, presets, steps } from "rlse.ts";
 
 export default defineConfig([
   steps.checkCleanWorkingTree(),
@@ -87,7 +87,7 @@ export default defineConfig([
 Use primitives directly only when you need full control over every side effect.
 
 ```ts filename=rlse.config.ts
-import { defineConfig, steps } from "release.ts";
+import { defineConfig, steps } from "rlse.ts";
 
 export default defineConfig([
   steps.resolvePackage({ name: "vanilla-ts" }),
@@ -210,7 +210,7 @@ Custom steps can be added with `(context) => { ... }`.
 CLI arguments can be declared with Zod in config and used when building the flow.
 
 ```ts filename=rlse.config.ts
-import { defineConfig, presets, z } from "release.ts";
+import { defineConfig, presets, z } from "rlse.ts";
 
 export default defineConfig({
   args: z.object({

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,10 +12,10 @@
   "author": "takuma-ru <takuma-ru@takumaru.dev> (https://github.com/takuma-ru/)",
   "repository": {
     "type": "git",
-    "url": "https://github.com/takuma-ru/rlse"
+    "url": "git+https://github.com/takuma-ru/rlse.git"
   },
   "bin": {
-    "rlse": "./bin/bin.js"
+    "rlse": "bin/bin.js"
   },
   "files": [
     "dist",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "release.ts",
+  "name": "rlse.ts",
   "version": "0.0.0",
   "private": false,
   "description": "TypeScript release workflow runner with reusable safety steps.",
@@ -65,7 +65,7 @@
   "devDependencies": {
     "@types/node": "^20.14.2",
     "@types/semver": "^7.5.8",
-    "release.ts": "workspace:*",
+    "rlse.ts": "workspace:*",
     "tsup": "^8.1.0",
     "typescript": "^5.2.2"
   }

--- a/packages/core/rlse.config.ts
+++ b/packages/core/rlse.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
         name: "github-actions[bot]",
         email: "41898282+github-actions[bot]@users.noreply.github.com",
       },
-      resolvePackage: { name: "release.ts" },
+      resolvePackage: { name: "rlse.ts" },
       calculateNextSemver: { level: args.level },
       runCommand: "pnpm build",
     }),

--- a/packages/core/src/config/loadRlseConfig.ts
+++ b/packages/core/src/config/loadRlseConfig.ts
@@ -87,9 +87,7 @@ const importTypeScriptConfig = async (filePath: string) => {
         noUnusedParameters: true,
         noFallthroughCasesInSwitch: true,
         paths: {
-          "release.ts": [
-            resolve(cwd(), "node_modules/release.ts/dist/main.js"),
-          ],
+          "rlse.ts": [resolve(cwd(), "node_modules/rlse.ts/dist/main.js")],
         },
       },
       exclude: ["node_modules"],

--- a/playgrounds/vanilla-ts/package.json
+++ b/playgrounds/vanilla-ts/package.json
@@ -16,7 +16,7 @@
     "rlse:test": "pnpm link:core && pnpm exec rlse"
   },
   "devDependencies": {
-    "release.ts": "workspace:*",
+    "rlse.ts": "workspace:*",
     "ts-node": "^10.9.2",
     "typescript": "^5.2.2",
     "vite": "^5.3.5"

--- a/playgrounds/vanilla-ts/rlse.config.ts
+++ b/playgrounds/vanilla-ts/rlse.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, presets, z } from "release.ts";
+import { defineConfig, presets, z } from "rlse.ts";
 
 export default defineConfig({
   args: z.object({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,7 +106,7 @@ importers:
       '@types/semver':
         specifier: ^7.5.8
         version: 7.5.8
-      release.ts:
+      rlse.ts:
         specifier: workspace:*
         version: 'link:'
       tsup:
@@ -118,7 +118,7 @@ importers:
 
   playgrounds/vanilla-ts:
     devDependencies:
-      release.ts:
+      rlse.ts:
         specifier: workspace:*
         version: link:../../packages/core
       ts-node:


### PR DESCRIPTION
## Summary
- Rename the package from `release.ts` to `rlse.ts` after npm rejected `release.ts` as too similar to `release-ts`.
- Update workspace dependencies, lockfile entries, docs examples, npm links, and release config references.
- Normalize npm manifest fields for the published package.

## Verification
- `pnpm p:core check`
- `pnpm -C packages/core build`
- `npm pack --dry-run`
- Published `rlse.ts@0.0.0` manually for the initial release