### PR TITLE
Update repository URLs after rename

### DIFF
--- a/docs/src/components/layouts/Header/Header.tsx
+++ b/docs/src/components/layouts/Header/Header.tsx
@@ -10,7 +10,7 @@ export const Header = () => {
       </a>
       <div className={links}>
         <a
-          href="https://github.com/takuma-ru/rlse"
+          href="https://github.com/takuma-ru/rlse.ts"
           target="_blank"
           rel="noreferrer"
         >

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": false,
   "description": "TypeScript release workflow runner with reusable safety steps.",
-  "homepage": "https://github.com/takuma-ru/rlse.ts",
+  "homepage": "https://rlse.takumaru.dev",
   "bugs": {
     "url": "https://github.com/takuma-ru/rlse.ts/issues",
     "email": "takuma-ru@takumaru.dev"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,16 +3,16 @@
   "version": "0.0.0",
   "private": false,
   "description": "TypeScript release workflow runner with reusable safety steps.",
-  "homepage": "https://github.com/takuma-ru/rlse",
+  "homepage": "https://github.com/takuma-ru/rlse.ts",
   "bugs": {
-    "url": "https://github.com/takuma-ru/rlse/issues",
+    "url": "https://github.com/takuma-ru/rlse.ts/issues",
     "email": "takuma-ru@takumaru.dev"
   },
   "license": "MPL-2.0",
   "author": "takuma-ru <takuma-ru@takumaru.dev> (https://github.com/takuma-ru/)",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/takuma-ru/rlse.git"
+    "url": "git+https://github.com/takuma-ru/rlse.ts.git"
   },
   "bin": {
     "rlse": "bin/bin.js"


### PR DESCRIPTION
## Summary
- Update package metadata URLs to `takuma-ru/rlse.ts`.
- Update the docs GitHub link to the renamed repository.

## Verification
- `pnpm p:core check`