### PR TITLE
Retry npm publish verification

### DIFF
--- a/packages/core/src/steps/publish/verifyPublishedNpmPackage.ts
+++ b/packages/core/src/steps/publish/verifyPublishedNpmPackage.ts
@@ -23,17 +23,10 @@ export const verifyPublishedNpmPackage = (options: {
       };
     }
 
-    const publishedVersion = cmdFile(
-      "npm",
-      ["view", `${packageName}@${version}`, "version"],
-      {
-        execOptions: {
-          cwd: context.cwd,
-          stdio: "pipe",
-          encoding: "utf8",
-        },
-        successCallback: (stdout) => stdout.trim(),
-      },
+    const publishedVersion = resolvePublishedVersionWithRetry(
+      packageName,
+      version,
+      context.cwd,
     );
 
     if (publishedVersion !== version) {
@@ -52,6 +45,48 @@ export const verifyPublishedNpmPackage = (options: {
     };
   },
 });
+
+const resolvePublishedVersionWithRetry = (
+  packageName: string,
+  version: string,
+  cwd: string,
+) => {
+  const maxAttempts = 6;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const publishedVersion = cmdFile(
+      "npm",
+      ["view", `${packageName}@${version}`, "version"],
+      {
+        execOptions: {
+          cwd,
+          stdio: "pipe",
+          encoding: "utf8",
+        },
+        successCallback: (stdout) => stdout.trim(),
+        silentError: attempt < maxAttempts,
+        errorCallback: (error) => {
+          if (attempt === maxAttempts) {
+            throw new Error(error.message);
+          }
+
+          consola.info(
+            `Waiting for ${packageName}@${version} to appear on npm (${attempt}/${maxAttempts})`,
+          );
+          Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 5_000);
+
+          return "";
+        },
+      },
+    );
+
+    if (publishedVersion) {
+      return publishedVersion;
+    }
+  }
+
+  throw new Error(`Unable to verify ${packageName}@${version} on npm`);
+};
 
 const wasNpmPublishSkipped = (
   context: Parameters<RlseStep["run"]>[0],


### PR DESCRIPTION
## Summary
- Retry `npm view` when verifying a freshly published package version.
- Avoid failing release workflows during npm registry propagation delays after a successful publish.

## Verification
- `pnpm p:core test`