### PR TITLE
Drop CJS support for TS 6 config loading

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -40,12 +40,11 @@ npm run rlse
 ## Configure settings via Setting file
 
 Create `rlse.config.ts` in the project root and export a release flow.
-In addition to ts, the following file formats are supported.
+The following ESM config file formats are supported.
 
 - `rlse.config.ts`
 - `rlse.config.js`
-  - `rlse.config.mjs`
-  - `rlse.config.cjs`
+- `rlse.config.mjs`
 - `rlse.config.json`
 
 ### Example

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,19 +24,13 @@
     "README.md"
   ],
   "type": "module",
-  "main": "./dist/main.cjs",
+  "main": "./dist/main.js",
   "module": "./dist/main.js",
   "types": "./dist/main.d.ts",
   "exports": {
     ".": {
-      "import": {
-        "default": "./dist/main.js",
-        "types": "./dist/main.d.ts"
-      },
-      "require": {
-        "default": "./dist/main.cjs",
-        "types": "./dist/main.d.cts"
-      }
+      "default": "./dist/main.js",
+      "types": "./dist/main.d.ts"
     }
   },
   "publishConfig": {

--- a/packages/core/src/config/loadRlseConfig.ts
+++ b/packages/core/src/config/loadRlseConfig.ts
@@ -3,11 +3,10 @@ import {
   existsSync,
   mkdirSync,
   readFile,
-  readFileSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { dirname, extname, parse, resolve } from "node:path";
+import { dirname, extname, resolve } from "node:path";
 import { cwd } from "node:process";
 import { promisify } from "node:util";
 import consola from "consola";
@@ -72,8 +71,9 @@ const importTypeScriptConfig = async (filePath: string) => {
       compilerOptions: {
         target: "ESNext",
         useDefineForClassFields: true,
-        module: "Node16",
-        moduleResolution: "node16",
+        module: "commonjs",
+        moduleResolution: "node",
+        ignoreDeprecations: "6.0",
         esModuleInterop: true,
         lib: ["ESNext"],
         skipLibCheck: true,
@@ -97,7 +97,7 @@ const importTypeScriptConfig = async (filePath: string) => {
   );
   writeFileSync(
     resolve(tempDir, "package.json"),
-    JSON.stringify({ type: getPackageType(filePath) }),
+    JSON.stringify({ type: "commonjs" }),
   );
 
   try {
@@ -113,30 +113,5 @@ const importTypeScriptConfig = async (filePath: string) => {
     throw error;
   } finally {
     rmSync(tempDir, { recursive: true, force: true });
-  }
-};
-
-const getPackageType = (filePath: string) => {
-  let currentDir = dirname(filePath);
-  const rootDir = parse(currentDir).root;
-
-  while (true) {
-    const packageJsonPath = resolve(currentDir, "package.json");
-
-    if (existsSync(packageJsonPath)) {
-      const packageJson = JSON.parse(
-        readFileSync(packageJsonPath, "utf-8"),
-      ) as {
-        type?: string;
-      };
-
-      return packageJson.type === "module" ? "module" : "commonjs";
-    }
-
-    if (currentDir === rootDir) {
-      return "commonjs";
-    }
-
-    currentDir = dirname(currentDir);
   }
 };

--- a/packages/core/src/config/loadRlseConfig.ts
+++ b/packages/core/src/config/loadRlseConfig.ts
@@ -20,7 +20,6 @@ const configFiles = [
   "rlse.config.ts",
   "rlse.config.js",
   "rlse.config.mjs",
-  "rlse.config.cjs",
   "rlse.config.json",
 ];
 
@@ -34,8 +33,7 @@ export const loadRlseConfig = async () => {
           return await importTypeScriptConfig(filePath);
         }
         case ".js":
-        case ".mjs":
-        case ".cjs": {
+        case ".mjs": {
           const config = await import(filePath);
 
           return config.default as RlseConfig;

--- a/packages/core/src/config/loadRlseConfig.ts
+++ b/packages/core/src/config/loadRlseConfig.ts
@@ -2,11 +2,14 @@ import { execSync } from "node:child_process";
 import {
   existsSync,
   mkdirSync,
+  readdirSync,
   readFile,
+  readFileSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from "node:fs";
-import { dirname, extname, resolve } from "node:path";
+import { dirname, extname, join, resolve } from "node:path";
 import { cwd } from "node:process";
 import { promisify } from "node:util";
 import consola from "consola";
@@ -71,9 +74,8 @@ const importTypeScriptConfig = async (filePath: string) => {
       compilerOptions: {
         target: "ESNext",
         useDefineForClassFields: true,
-        module: "commonjs",
-        moduleResolution: "node",
-        ignoreDeprecations: "6.0",
+        module: "ESNext",
+        moduleResolution: "bundler",
         esModuleInterop: true,
         lib: ["ESNext"],
         skipLibCheck: true,
@@ -97,13 +99,14 @@ const importTypeScriptConfig = async (filePath: string) => {
   );
   writeFileSync(
     resolve(tempDir, "package.json"),
-    JSON.stringify({ type: "commonjs" }),
+    JSON.stringify({ type: "module" }),
   );
 
   try {
     execSync(`tsc --project ${customTsConfigPath}`, {
       stdio: "inherit",
     });
+    addJsExtensionsToRelativeImports(tempDir);
     const config = await import(tempFilePath);
 
     return (config.default.default ?? config.default) as RlseConfig;
@@ -113,5 +116,40 @@ const importTypeScriptConfig = async (filePath: string) => {
     throw error;
   } finally {
     rmSync(tempDir, { recursive: true, force: true });
+  }
+};
+
+const addJsExtensionsToRelativeImports = (dir: string) => {
+  for (const entry of readdirSync(dir)) {
+    const filePath = join(dir, entry);
+    const stat = statSync(filePath);
+
+    if (stat.isDirectory()) {
+      addJsExtensionsToRelativeImports(filePath);
+      continue;
+    }
+
+    if (extname(filePath) !== ".js") {
+      continue;
+    }
+
+    const content = readFileSync(filePath, "utf-8");
+    const updatedContent = content.replace(
+      /(from\s+["']|import\s*\(\s*["'])(\.{1,2}\/[^"']+)(["'])/g,
+      (match, prefix: string, importPath: string, suffix: string) => {
+        if (
+          extname(importPath) ||
+          !existsSync(resolve(dirname(filePath), `${importPath}.js`))
+        ) {
+          return match;
+        }
+
+        return `${prefix}${importPath}.js${suffix}`;
+      },
+    );
+
+    if (updatedContent !== content) {
+      writeFileSync(filePath, updatedContent);
+    }
   }
 };

--- a/packages/core/test/config-version.test.mjs
+++ b/packages/core/test/config-version.test.mjs
@@ -365,6 +365,29 @@ export default defineConfig(
   }
 });
 
+test("does not load CommonJS config", () => {
+  const projectDir = createTempProject();
+
+  try {
+    writeFileSync(
+      path.join(projectDir, "rlse.config.cjs"),
+      `module.exports = [];
+`,
+    );
+
+    assert.throws(
+      () =>
+        execFileSync("node", [cliPath], {
+          cwd: projectDir,
+          stdio: "pipe",
+        }),
+      /No configuration file found/,
+    );
+  } finally {
+    rmSync(projectDir, { recursive: true, force: true });
+  }
+});
+
 test("collects flow step results", async () => {
   const { runFlow } = await import(publicApiPath);
 

--- a/packages/core/test/config-version.test.mjs
+++ b/packages/core/test/config-version.test.mjs
@@ -309,6 +309,62 @@ export default defineConfig(
   }
 });
 
+test("loads TypeScript config with extensionless relative import", () => {
+  const projectDir = createTempProject();
+
+  try {
+    writeFileSync(
+      path.join(projectDir, "package.json"),
+      JSON.stringify(
+        {
+          name: "rlse-config-version-fixture",
+          version: "1.2.3",
+          type: "module",
+        },
+        null,
+        2,
+      ),
+    );
+    mkdirSync(path.join(projectDir, "node_modules"), { recursive: true });
+    symlinkSync(packageRoot, path.join(projectDir, "node_modules", "rlse.ts"));
+
+    writeFileSync(
+      path.join(projectDir, "release-options.ts"),
+      `export const releaseVersion = "6.0.0";
+`,
+    );
+    writeFileSync(
+      path.join(projectDir, "rlse.config.ts"),
+      `import { defineConfig, presets } from "rlse.ts";
+import { releaseVersion } from "./release-options";
+
+export default defineConfig(
+  presets.npmRelease({
+    resolvePackage: { name: "rlse-config-version-fixture" },
+    calculateNextSemver: { version: releaseVersion },
+    publishNpmPackage: false,
+    commit: false,
+    push: false,
+  }),
+);
+`,
+    );
+
+    execFileSync("node", [cliPath], {
+      cwd: projectDir,
+      stdio: "pipe",
+    });
+
+    const packageJson = JSON.parse(
+      readFileSync(path.join(projectDir, "package.json"), "utf8"),
+    );
+
+    assert.equal(packageJson.version, "6.0.0");
+  } finally {
+    rmSync(projectDir, { recursive: true, force: true });
+  }
+});
+
 test("collects flow step results", async () => {
   const { runFlow } = await import(publicApiPath);
 

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -1,11 +1,11 @@
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { cwd } from "node:process";
 import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: ["src/main.ts", "src/bin.ts"],
-  format: ["esm", "cjs"],
+  format: ["esm"],
   target: "esnext",
   splitting: false,
   sourcemap: true,
@@ -13,9 +13,10 @@ export default defineConfig({
   dts: true,
   onSuccess: async () => {
     const binDir = path.join(cwd(), "bin");
+    await rm(binDir, { recursive: true, force: true });
     await mkdir(binDir, { recursive: true });
 
-    const filesToCopy = ["dist/bin.cjs", "dist/bin.js"];
+    const filesToCopy = ["dist/bin.js"];
 
     for (const file of filesToCopy) {
       const content = await readFile(file, { encoding: "utf8" });


### PR DESCRIPTION
## Summary
- Drop CommonJS/CTS support from the package build, exports, and config file discovery.
- Compile `rlse.config.ts` as ESM with `moduleResolution: bundler` so TypeScript 6 no longer needs deprecated `node`/`node10` config options.
- Keep extensionless relative imports in TypeScript configs working by rewriting generated relative JS imports to include `.js` when needed.
- Add regression coverage that `.cjs` configs are ignored and extensionless TypeScript config imports still load.

## Verification
- `pnpm -C packages/core test`
- `pnpm check`

## Notes
- Fixes the release workflow failure from run 25803495114.
- This intentionally removes CJS/CTS output and `rlse.config.cjs` support.