### PR TITLE
Improve npm publish dry-run version validation

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -192,11 +192,15 @@ The following steps are exported from `steps`.
 
 **Release Outputs**
 
-| Step                               | Description                                                                             | Options                                         |
-| ---------------------------------- | --------------------------------------------------------------------------------------- | ----------------------------------------------- |
-| `steps.publishNpmPackage(options)` | Publishes a package with `npm publish`.                                                 | `packageName`, `packageDir`, `dryRun`.          |
-| `steps.githubRelease(options)`     | Creates a GitHub Release with `gh release create` and deletes it if a later step fails. | `tag`, `title`, `notes`, `draft`, `prerelease`. |
-| `steps.updateChangelog(options)`   | Adds a version entry to a changelog and rolls it back if a later step fails.            | `version`, `path`, `date`, `changes`.           |
+| Step                               | Description                                                                             | Options                                                 |
+| ---------------------------------- | --------------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| `steps.publishNpmPackage(options)` | Publishes a package with `npm publish`.                                                 | `packageName`, `packageDir`, `dryRun`, `dryRunVersion`. |
+| `steps.githubRelease(options)`     | Creates a GitHub Release with `gh release create` and deletes it if a later step fails. | `tag`, `title`, `notes`, `draft`, `prerelease`.         |
+| `steps.updateChangelog(options)`   | Adds a version entry to a changelog and rolls it back if a later step fails.            | `version`, `path`, `date`, `changes`.                   |
+
+When `dryRunVersion` is provided and publish runs in dry-run mode,
+`publishNpmPackage` temporarily writes that version to `package.json`, runs
+`npm publish --dry-run`, and restores the original file content afterward.
 
 **Commands**
 

--- a/packages/core/src/presets/index.ts
+++ b/packages/core/src/presets/index.ts
@@ -84,6 +84,8 @@ export const npmRelease = (options: NpmReleaseOptions): RlseFlowStep[] => {
         packageName: (context) => getResolvePackageResult(context).packageName,
         packageDir: (context) =>
           path.dirname(getResolvePackageResult(context).packageJsonPath),
+        dryRunVersion: (context) =>
+          getCalculateNextSemverResult(context).nextVersion,
       }),
     );
 

--- a/packages/core/src/steps/publish/publish.ts
+++ b/packages/core/src/steps/publish/publish.ts
@@ -1,3 +1,5 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
 import consola from "consola";
 import type { RlseStep } from "../../flow/types";
 import { cmdFile } from "../../utils/cmd";
@@ -7,6 +9,7 @@ export const publishNpmPackage = (options: {
   packageName: Resolvable<string>;
   packageDir?: Resolvable<string>;
   dryRun?: boolean;
+  dryRunVersion?: Resolvable<string>;
 }): RlseStep => ({
   name: "publishNpmPackage",
   run: (context) => {
@@ -15,28 +18,68 @@ export const publishNpmPackage = (options: {
       ? resolveOption(options.packageDir, context)
       : context.cwd;
     const dryRun = options.dryRun ?? context.dryRun;
+    const dryRunVersion = options.dryRunVersion
+      ? resolveOption(options.dryRunVersion, context)
+      : undefined;
 
     const publishArgs = ["publish"];
     if (dryRun) {
       publishArgs.push("--dry-run");
     }
 
-    cmdFile("npm", publishArgs, {
-      execOptions: {
-        cwd: packageDir,
-        encoding: "utf8",
-      },
-      successCallback: (stdout) => {
-        consola.success(`Published ${packageName}`);
-        return stdout;
-      },
-    });
+    if (dryRun && dryRunVersion) {
+      withTemporaryPackageVersion(packageDir, dryRunVersion, () => {
+        publish(packageDir, packageName, publishArgs);
+      });
+    } else {
+      publish(packageDir, packageName, publishArgs);
+    }
 
     return {
       packageName,
       packageDir,
       dryRun,
+      dryRunVersion,
       published: !dryRun,
     };
   },
 });
+
+const publish = (
+  packageDir: string,
+  packageName: string,
+  publishArgs: string[],
+) => {
+  cmdFile("npm", publishArgs, {
+    execOptions: {
+      cwd: packageDir,
+      encoding: "utf8",
+    },
+    successCallback: (stdout) => {
+      consola.success(`Published ${packageName}`);
+      return stdout;
+    },
+  });
+};
+
+const withTemporaryPackageVersion = (
+  packageDir: string,
+  version: string,
+  callback: () => void,
+) => {
+  const packageJsonPath = path.join(packageDir, "package.json");
+  const originalPackageJson = readFileSync(packageJsonPath, "utf8");
+  const packageJson = JSON.parse(originalPackageJson) as Record<
+    string,
+    unknown
+  >;
+
+  packageJson.version = version;
+  writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
+
+  try {
+    callback();
+  } finally {
+    writeFileSync(packageJsonPath, originalPackageJson);
+  }
+};

--- a/packages/core/test/config-version.test.mjs
+++ b/packages/core/test/config-version.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { execFileSync, execSync } from "node:child_process";
 import {
+  chmodSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -654,6 +655,112 @@ test("skips npm publish verification after dry-run publish", async () => {
     dryRun: true,
     verified: false,
   });
+});
+
+test("temporarily writes dry-run publish version and restores package json", async () => {
+  const projectDir = createTempProject();
+  const binDir = path.join(projectDir, "bin");
+  const npmRecordPath = path.join(projectDir, "npm-record.json");
+  const packageJsonPath = path.join(projectDir, "package.json");
+  const originalPath = process.env.PATH;
+  const originalPackageJson = readFileSync(packageJsonPath, "utf8");
+
+  try {
+    mkdirSync(binDir);
+    writeFileSync(
+      path.join(binDir, "npm"),
+      `#!/usr/bin/env node
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+const packageJson = JSON.parse(
+  readFileSync(path.join(process.cwd(), "package.json"), "utf8"),
+);
+
+writeFileSync(
+  process.env.RLSE_TEST_NPM_RECORD,
+  JSON.stringify({ argv: process.argv.slice(2), version: packageJson.version }),
+);
+`,
+    );
+    chmodSync(path.join(binDir, "npm"), 0o755);
+    process.env.PATH = `${binDir}${path.delimiter}${originalPath}`;
+    process.env.RLSE_TEST_NPM_RECORD = npmRecordPath;
+
+    const { runFlow, steps } = await import(publicApiPath);
+
+    const context = await runFlow(
+      [
+        steps.publishNpmPackage({
+          packageName: "rlse-config-version-fixture",
+          packageDir: projectDir,
+          dryRun: true,
+          dryRunVersion: "9.9.9",
+        }),
+      ],
+      { cwd: projectDir },
+    );
+
+    assert.equal(readFileSync(packageJsonPath, "utf8"), originalPackageJson);
+    assert.deepEqual(JSON.parse(readFileSync(npmRecordPath, "utf8")), {
+      argv: ["publish", "--dry-run"],
+      version: "9.9.9",
+    });
+    assert.deepEqual(context.results.findStep("publishNpmPackage"), {
+      packageName: "rlse-config-version-fixture",
+      packageDir: projectDir,
+      dryRun: true,
+      dryRunVersion: "9.9.9",
+      published: false,
+    });
+  } finally {
+    process.env.PATH = originalPath;
+    delete process.env.RLSE_TEST_NPM_RECORD;
+    rmSync(projectDir, { recursive: true, force: true });
+  }
+});
+
+test("restores dry-run publish version when npm publish fails", async () => {
+  const projectDir = createTempProject();
+  const binDir = path.join(projectDir, "bin");
+  const packageJsonPath = path.join(projectDir, "package.json");
+  const originalPath = process.env.PATH;
+  const originalPackageJson = readFileSync(packageJsonPath, "utf8");
+
+  try {
+    mkdirSync(binDir);
+    writeFileSync(
+      path.join(binDir, "npm"),
+      `#!/usr/bin/env node
+process.exit(1);
+`,
+    );
+    chmodSync(path.join(binDir, "npm"), 0o755);
+    process.env.PATH = `${binDir}${path.delimiter}${originalPath}`;
+
+    const { runFlow, steps } = await import(publicApiPath);
+
+    await assert.rejects(
+      () =>
+        runFlow(
+          [
+            steps.publishNpmPackage({
+              packageName: "rlse-config-version-fixture",
+              packageDir: projectDir,
+              dryRun: true,
+              dryRunVersion: "9.9.9",
+            }),
+          ],
+          { cwd: projectDir },
+        ),
+      /Command failed/,
+    );
+
+    assert.equal(readFileSync(packageJsonPath, "utf8"), originalPackageJson);
+  } finally {
+    process.env.PATH = originalPath;
+    rmSync(projectDir, { recursive: true, force: true });
+  }
 });
 
 test("rejects config args that collide with built-in dry-run", () => {


### PR DESCRIPTION
## Summary
- add publishNpmPackage dryRunVersion support for validating npm publish against the computed next version
- temporarily write package.json version during dry-run publish and restore the original file content afterward
- wire npmRelease to pass the calculated next version into dry-run publish validation

## Tests
- pnpm -C packages/core check
- pnpm -C packages/core test

Fixes #37