### PR TITLE
Add pushTag rollback step

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -181,14 +181,15 @@ The following steps are exported from `steps`.
 
 **Git**
 
-| Step                                 | Description                                              | Options                            |
-| ------------------------------------ | -------------------------------------------------------- | ---------------------------------- |
-| `steps.configureGitUser(options)`    | Configures local git author settings for the repository. | `name`, `email`.                   |
-| `steps.createReleaseBranch(options)` | Creates and switches to a local release branch.          | `branch`.                          |
-| `steps.stageFiles(options)`          | Stages files with `git add`.                             | `paths`.                           |
-| `steps.commit(options)`              | Commits staged files.                                    | `message`, `skipIfNoChanges`.      |
-| `steps.tag(options)`                 | Creates a git tag and deletes it if a later step fails.  | `name`, `message`.                 |
-| `steps.push(options)`                | Pushes a branch to a remote.                             | `branch`, `remote`, `setUpstream`. |
+| Step                                 | Description                                                    | Options                            |
+| ------------------------------------ | -------------------------------------------------------------- | ---------------------------------- |
+| `steps.configureGitUser(options)`    | Configures local git author settings for the repository.       | `name`, `email`.                   |
+| `steps.createReleaseBranch(options)` | Creates and switches to a local release branch.                | `branch`.                          |
+| `steps.stageFiles(options)`          | Stages files with `git add`.                                   | `paths`.                           |
+| `steps.commit(options)`              | Commits staged files.                                          | `message`, `skipIfNoChanges`.      |
+| `steps.tag(options)`                 | Creates a git tag and deletes it if a later step fails.        | `name`, `message`.                 |
+| `steps.push(options)`                | Pushes a branch to a remote.                                   | `branch`, `remote`, `setUpstream`. |
+| `steps.pushTag(options)`             | Pushes a tag to a remote and deletes it if a later step fails. | `tag`, `remote`.                   |
 
 **Release Outputs**
 

--- a/packages/core/src/flow/types.ts
+++ b/packages/core/src/flow/types.ts
@@ -60,6 +60,12 @@ export type RlseKnownStepResults = {
     dryRun: boolean;
     released: boolean;
   };
+  pushTag: {
+    tag: string;
+    remote: string;
+    dryRun: boolean;
+    pushed: boolean;
+  };
   updateChangelog: {
     path: string;
     version: string;

--- a/packages/core/src/steps/git/pushTag.ts
+++ b/packages/core/src/steps/git/pushTag.ts
@@ -1,0 +1,78 @@
+import consola from "consola";
+import type { RlseStep } from "../../flow/types";
+import { cmdFile } from "../../utils/cmd";
+import { resolveOption, type Resolvable } from "../resolveOption";
+
+export const pushTag = (options: {
+  tag: Resolvable<string>;
+  remote?: Resolvable<string>;
+}): RlseStep => ({
+  name: "pushTag",
+  run: (context) => {
+    const tag = resolveOption(options.tag, context);
+    const remote = options.remote
+      ? resolveOption(options.remote, context)
+      : "origin";
+    const args = ["push", remote, `refs/tags/${tag}`];
+
+    if (context.dryRun) {
+      consola.info(`[dry-run] Skip git ${args.join(" ")}`);
+
+      return {
+        tag,
+        remote,
+        dryRun: true,
+        pushed: false,
+      };
+    }
+
+    cmdFile("git", args, {
+      execOptions: {
+        cwd: context.cwd,
+        encoding: "utf8",
+      },
+      successCallback: (stdout) => {
+        consola.success(`Pushed tag ${tag} to ${remote}`);
+        return stdout;
+      },
+    });
+
+    return {
+      tag,
+      remote,
+      dryRun: false,
+      pushed: true,
+    };
+  },
+  rollback: (context, result) => {
+    if (!isPushTagResult(result.value) || !result.value.pushed) {
+      return;
+    }
+
+    cmdFile(
+      "git",
+      ["push", result.value.remote, `:refs/tags/${result.value.tag}`],
+      {
+        execOptions: {
+          cwd: context.cwd,
+          encoding: "utf8",
+        },
+      },
+    );
+  },
+});
+
+const isPushTagResult = (
+  value: unknown,
+): value is { tag: string; remote: string; pushed: boolean } => {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "tag" in value &&
+    typeof value.tag === "string" &&
+    "remote" in value &&
+    typeof value.remote === "string" &&
+    "pushed" in value &&
+    typeof value.pushed === "boolean"
+  );
+};

--- a/packages/core/src/steps/index.ts
+++ b/packages/core/src/steps/index.ts
@@ -8,6 +8,7 @@ export * from "./git/commit";
 export * from "./git/configureGit";
 export * from "./git/createReleaseBranch";
 export * from "./git/push";
+export * from "./git/pushTag";
 export * from "./git/stageFiles";
 export * from "./git/tag";
 export * from "./package/resolvePackage";

--- a/packages/core/test/config-version.test.mjs
+++ b/packages/core/test/config-version.test.mjs
@@ -534,6 +534,72 @@ test("rolls back created git tags when a later step fails", async () => {
   }
 });
 
+test("rolls back pushed git tags when a later step fails", async () => {
+  const projectDir = createTempProject();
+  const remoteDir = mkdtempSync(path.join(tmpdir(), "rlse-remote-"));
+
+  try {
+    commitAll(projectDir);
+    execFileSync("git", ["init", "--bare", remoteDir], {
+      stdio: "pipe",
+    });
+
+    const { runFlow, steps } = await import(publicApiPath);
+
+    await assert.rejects(
+      () =>
+        runFlow(
+          [
+            steps.tag({ name: "v1.2.3" }),
+            steps.pushTag({ tag: "v1.2.3", remote: remoteDir }),
+            {
+              name: "fail",
+              run: () => {
+                throw new Error("fail after push tag");
+              },
+            },
+          ],
+          { cwd: projectDir },
+        ),
+      /fail after push tag/,
+    );
+
+    const remoteTags = execFileSync(
+      "git",
+      ["--git-dir", remoteDir, "tag", "--list", "v1.2.3"],
+      {
+        encoding: "utf8",
+      },
+    ).trim();
+    const localTags = execFileSync("git", ["tag", "--list", "v1.2.3"], {
+      cwd: projectDir,
+      encoding: "utf8",
+    }).trim();
+
+    assert.equal(remoteTags, "");
+    assert.equal(localTags, "");
+  } finally {
+    rmSync(projectDir, { recursive: true, force: true });
+    rmSync(remoteDir, { recursive: true, force: true });
+  }
+});
+
+test("skips pushing git tags during dry-run", async () => {
+  const { runFlow, steps } = await import(publicApiPath);
+
+  const context = await runFlow(
+    [steps.pushTag({ tag: "v1.2.3", remote: "origin" })],
+    { dryRun: true },
+  );
+
+  assert.deepEqual(context.results.findStep("pushTag"), {
+    tag: "v1.2.3",
+    remote: "origin",
+    dryRun: true,
+    pushed: false,
+  });
+});
+
 test("skips github release creation during dry-run", async () => {
   const { runFlow, steps } = await import(publicApiPath);
 


### PR DESCRIPTION
## Summary
- add a new steps.pushTag helper for explicitly pushing Git tags to a remote
- rollback pushed remote tags with an explicit :refs/tags/<tag> refspec
- document pushTag and cover rollback plus dry-run behavior in tests

Closes #35

## Verification
- pnpm -C packages/core test
- pnpm -C packages/core check