### PR TITLE
Add rerunnable git artifact helpers

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -83,6 +83,25 @@ export default defineConfig([
 ]);
 ```
 
+Use `releaseBranchName` and `env` when a CI flow needs rerunnable
+version-derived branch names from environment variables.
+
+```ts filename=rlse.config.ts
+import { defineConfig, steps } from "rlse.ts";
+
+const releaseBranch = steps.releaseBranchName({
+  version: ({ results }) => results.findStep("calculateNextSemver").nextVersion,
+  suffix: steps.env(["GITHUB_RUN_ID", "GITHUB_RUN_ATTEMPT"]),
+});
+
+export default defineConfig([
+  // version calculation steps...
+  steps.createReleaseBranch({ branch: releaseBranch, ifExists: "skip" }),
+  // release side-effect steps...
+  steps.push({ branch: releaseBranch, setUpstream: true, ifExists: "skip" }),
+]);
+```
+
 Use primitives directly only when you need full control over every side effect.
 
 ```ts filename=rlse.config.ts
@@ -141,14 +160,14 @@ Rlse exports `defineConfig`, `presets`, `steps`, `runFlow`, and `z`.
 Use presets for the common path. Use individual steps when you need to insert,
 remove, or reorder release side effects.
 
-| Group           | Steps                                                                                     |
-| --------------- | ----------------------------------------------------------------------------------------- |
-| Auth checks     | `checkAuth`, `checkGitHubAuth`, `checkNpmToken`                                           |
-| Package/version | `resolvePackage`, `resolvePublishedVersion`, `calculateNextSemver`, `writePackageVersion` |
-| Safety checks   | `checkCleanWorkingTree`, `checkNpmPackageVersionAvailable`, `verifyPublishedNpmPackage`   |
-| Git operations  | `configureGitUser`, `createReleaseBranch`, `stageFiles`, `commit`, `tag`, `push`          |
-| Release outputs | `publishNpmPackage`, `githubRelease`, `updateChangelog`                                   |
-| Commands        | `runCommand`                                                                              |
+| Group           | Steps                                                                                                                   |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| Auth checks     | `checkAuth`, `checkGitHubAuth`, `checkNpmToken`                                                                         |
+| Package/version | `resolvePackage`, `resolvePublishedVersion`, `calculateNextSemver`, `writePackageVersion`                               |
+| Safety checks   | `checkCleanWorkingTree`, `checkNpmPackageVersionAvailable`, `verifyPublishedNpmPackage`                                 |
+| Git operations  | `configureGitUser`, `createReleaseBranch`, `releaseBranchName`, `env`, `stageFiles`, `commit`, `tag`, `push`, `pushTag` |
+| Release outputs | `publishNpmPackage`, `githubRelease`, `updateChangelog`                                                                 |
+| Commands        | `runCommand`                                                                                                            |
 
 #### Step Reference
 
@@ -181,15 +200,17 @@ The following steps are exported from `steps`.
 
 **Git**
 
-| Step                                 | Description                                                    | Options                            |
-| ------------------------------------ | -------------------------------------------------------------- | ---------------------------------- |
-| `steps.configureGitUser(options)`    | Configures local git author settings for the repository.       | `name`, `email`.                   |
-| `steps.createReleaseBranch(options)` | Creates and switches to a local release branch.                | `branch`.                          |
-| `steps.stageFiles(options)`          | Stages files with `git add`.                                   | `paths`.                           |
-| `steps.commit(options)`              | Commits staged files.                                          | `message`, `skipIfNoChanges`.      |
-| `steps.tag(options)`                 | Creates a git tag and deletes it if a later step fails.        | `name`, `message`.                 |
-| `steps.push(options)`                | Pushes a branch to a remote.                                   | `branch`, `remote`, `setUpstream`. |
-| `steps.pushTag(options)`             | Pushes a tag to a remote and deletes it if a later step fails. | `tag`, `remote`.                   |
+| Step                                 | Description                                                       | Options                                        |
+| ------------------------------------ | ----------------------------------------------------------------- | ---------------------------------------------- |
+| `steps.configureGitUser(options)`    | Configures local git author settings for the repository.          | `name`, `email`.                               |
+| `steps.createReleaseBranch(options)` | Creates and switches to a local release branch.                   | `branch`, `ifExists`.                          |
+| `steps.releaseBranchName(options)`   | Returns a resolvable release branch name with an optional suffix. | `version`, `prefix`, `suffix`, `separator`.    |
+| `steps.env(names, options)`          | Reads one or more environment variables for config values.        | `names`, `fallback`, `separator`.              |
+| `steps.stageFiles(options)`          | Stages files with `git add`.                                      | `paths`.                                       |
+| `steps.commit(options)`              | Commits staged files.                                             | `message`, `skipIfNoChanges`.                  |
+| `steps.tag(options)`                 | Creates a git tag and deletes it if a later step fails.           | `name`, `message`, `ifExists`.                 |
+| `steps.push(options)`                | Pushes a branch to a remote.                                      | `branch`, `remote`, `setUpstream`, `ifExists`. |
+| `steps.pushTag(options)`             | Pushes a tag to a remote and deletes it if a later step fails.    | `tag`, `remote`, `ifExists`.                   |
 
 **Release Outputs**
 

--- a/packages/core/src/flow/types.ts
+++ b/packages/core/src/flow/types.ts
@@ -35,11 +35,21 @@ export type RlseKnownStepResults = {
     clean: boolean;
     allowUntracked: boolean;
   };
+  createReleaseBranch: {
+    baseBranch: string;
+    branch: string;
+    dryRun: boolean;
+    created: boolean;
+    skipped: boolean;
+    replaced: boolean;
+  };
   tag: {
     name: string;
     message?: string;
     dryRun: boolean;
     tagged: boolean;
+    skipped: boolean;
+    replaced: boolean;
   };
   checkGitHubAuth: {
     authenticated: boolean;
@@ -65,6 +75,8 @@ export type RlseKnownStepResults = {
     remote: string;
     dryRun: boolean;
     pushed: boolean;
+    skipped: boolean;
+    replaced: boolean;
   };
   updateChangelog: {
     path: string;
@@ -85,6 +97,15 @@ export type RlseKnownStepResults = {
     version: string;
     dryRun: boolean;
     verified: boolean;
+  };
+  push: {
+    branch: string;
+    remote: string;
+    setUpstream: boolean;
+    dryRun: boolean;
+    pushed: boolean;
+    skipped: boolean;
+    replaced: boolean;
   };
 };
 

--- a/packages/core/src/flow/types.ts
+++ b/packages/core/src/flow/types.ts
@@ -41,7 +41,6 @@ export type RlseKnownStepResults = {
     dryRun: boolean;
     created: boolean;
     skipped: boolean;
-    replaced: boolean;
   };
   tag: {
     name: string;
@@ -49,7 +48,6 @@ export type RlseKnownStepResults = {
     dryRun: boolean;
     tagged: boolean;
     skipped: boolean;
-    replaced: boolean;
   };
   checkGitHubAuth: {
     authenticated: boolean;
@@ -76,7 +74,6 @@ export type RlseKnownStepResults = {
     dryRun: boolean;
     pushed: boolean;
     skipped: boolean;
-    replaced: boolean;
   };
   updateChangelog: {
     path: string;
@@ -105,7 +102,6 @@ export type RlseKnownStepResults = {
     dryRun: boolean;
     pushed: boolean;
     skipped: boolean;
-    replaced: boolean;
   };
 };
 

--- a/packages/core/src/steps/git/createReleaseBranch.ts
+++ b/packages/core/src/steps/git/createReleaseBranch.ts
@@ -45,7 +45,6 @@ export const createReleaseBranch = (options: {
         dryRun: context.dryRun,
         created: false,
         skipped: true,
-        replaced: false,
       };
     }
 
@@ -58,17 +57,7 @@ export const createReleaseBranch = (options: {
         dryRun: true,
         created: false,
         skipped: false,
-        replaced: false,
       };
-    }
-
-    if (exists && ifExists === "replace") {
-      cmdFile("git", ["branch", "-D", branch], {
-        execOptions: {
-          cwd: context.cwd,
-          encoding: "utf8",
-        },
-      });
     }
 
     cmdFile("git", ["switch", "-c", branch], {
@@ -88,7 +77,6 @@ export const createReleaseBranch = (options: {
       dryRun: false,
       created: true,
       skipped: false,
-      replaced: exists && ifExists === "replace",
     };
   },
   rollback: (context, result) => {

--- a/packages/core/src/steps/git/createReleaseBranch.ts
+++ b/packages/core/src/steps/git/createReleaseBranch.ts
@@ -2,13 +2,18 @@ import consola from "consola";
 import type { RlseStep } from "../../flow/types";
 import { cmdFile } from "../../utils/cmd";
 import { resolveOption, type Resolvable } from "../resolveOption";
+import type { GitArtifactIfExists } from "./releaseArtifacts";
 
 export const createReleaseBranch = (options: {
   branch: Resolvable<string>;
+  ifExists?: Resolvable<GitArtifactIfExists>;
 }): RlseStep => ({
   name: "createReleaseBranch",
   run: (context) => {
     const branch = resolveOption(options.branch, context);
+    const ifExists = options.ifExists
+      ? resolveOption(options.ifExists, context)
+      : "fail";
     const baseBranch = cmdFile("git", ["branch", "--show-current"], {
       execOptions: {
         cwd: context.cwd,
@@ -20,6 +25,29 @@ export const createReleaseBranch = (options: {
         return stdout.trim();
       },
     });
+    const exists = localBranchExists(branch, context.cwd);
+
+    if (exists && ifExists === "skip") {
+      consola.info(`Branch ${branch} already exists; switching to it`);
+
+      if (!context.dryRun) {
+        cmdFile("git", ["switch", branch], {
+          execOptions: {
+            cwd: context.cwd,
+            encoding: "utf8",
+          },
+        });
+      }
+
+      return {
+        baseBranch,
+        branch,
+        dryRun: context.dryRun,
+        created: false,
+        skipped: true,
+        replaced: false,
+      };
+    }
 
     if (context.dryRun) {
       consola.info(`[dry-run] Skip git switch -c ${branch}`);
@@ -29,7 +57,18 @@ export const createReleaseBranch = (options: {
         branch,
         dryRun: true,
         created: false,
+        skipped: false,
+        replaced: false,
       };
+    }
+
+    if (exists && ifExists === "replace") {
+      cmdFile("git", ["branch", "-D", branch], {
+        execOptions: {
+          cwd: context.cwd,
+          encoding: "utf8",
+        },
+      });
     }
 
     cmdFile("git", ["switch", "-c", branch], {
@@ -48,31 +87,44 @@ export const createReleaseBranch = (options: {
       branch,
       dryRun: false,
       created: true,
+      skipped: false,
+      replaced: exists && ifExists === "replace",
     };
   },
   rollback: (context, result) => {
-    if (!isCreateReleaseBranchResult(result.value) || !result.value.created) {
+    if (!isCreateReleaseBranchResult(result.value) || result.value.dryRun) {
       return;
     }
 
-    cmdFile("git", ["switch", result.value.baseBranch], {
-      execOptions: {
-        cwd: context.cwd,
-        encoding: "utf8",
-      },
-    });
-    cmdFile("git", ["branch", "-D", result.value.branch], {
-      execOptions: {
-        cwd: context.cwd,
-        encoding: "utf8",
-      },
-    });
+    if (result.value.created || result.value.skipped) {
+      cmdFile("git", ["switch", result.value.baseBranch], {
+        execOptions: {
+          cwd: context.cwd,
+          encoding: "utf8",
+        },
+      });
+    }
+
+    if (result.value.created) {
+      cmdFile("git", ["branch", "-D", result.value.branch], {
+        execOptions: {
+          cwd: context.cwd,
+          encoding: "utf8",
+        },
+      });
+    }
   },
 });
 
 const isCreateReleaseBranchResult = (
   value: unknown,
-): value is { baseBranch: string; branch: string; created: boolean } => {
+): value is {
+  baseBranch: string;
+  branch: string;
+  dryRun: boolean;
+  created: boolean;
+  skipped: boolean;
+} => {
   return (
     typeof value === "object" &&
     value !== null &&
@@ -80,7 +132,25 @@ const isCreateReleaseBranchResult = (
     typeof value.baseBranch === "string" &&
     "branch" in value &&
     typeof value.branch === "string" &&
+    "dryRun" in value &&
+    typeof value.dryRun === "boolean" &&
     "created" in value &&
-    typeof value.created === "boolean"
+    typeof value.created === "boolean" &&
+    "skipped" in value &&
+    typeof value.skipped === "boolean"
+  );
+};
+
+const localBranchExists = (branch: string, cwd: string) => {
+  return Boolean(
+    cmdFile("git", ["rev-parse", "--verify", `refs/heads/${branch}`], {
+      execOptions: {
+        cwd,
+        stdio: "pipe",
+        encoding: "utf8",
+      },
+      errorCallback: () => "",
+      silentError: true,
+    }),
   );
 };

--- a/packages/core/src/steps/git/push.ts
+++ b/packages/core/src/steps/git/push.ts
@@ -42,16 +42,7 @@ export const push = (options: {
         dryRun: context.dryRun,
         pushed: false,
         skipped: true,
-        replaced: false,
       };
-    }
-
-    if (exists && ifExists === "replace") {
-      args.splice(
-        1,
-        0,
-        `--force-with-lease=refs/heads/${branch}:${remoteHead}`,
-      );
     }
 
     if (context.dryRun) {
@@ -64,7 +55,6 @@ export const push = (options: {
         dryRun: true,
         pushed: false,
         skipped: false,
-        replaced: false,
       };
     }
 
@@ -86,7 +76,6 @@ export const push = (options: {
       dryRun: false,
       pushed: true,
       skipped: false,
-      replaced: exists && ifExists === "replace",
     };
   },
 });

--- a/packages/core/src/steps/git/push.ts
+++ b/packages/core/src/steps/git/push.ts
@@ -1,28 +1,70 @@
 import consola from "consola";
 import type { RlseStep } from "../../flow/types";
 import { cmdFile } from "../../utils/cmd";
+import { resolveOption, type Resolvable } from "../resolveOption";
+import type { GitArtifactIfExists } from "./releaseArtifacts";
 
 export const push = (options: {
-  branch: string;
-  remote?: string;
-  setUpstream?: boolean;
+  branch: Resolvable<string>;
+  remote?: Resolvable<string>;
+  setUpstream?: Resolvable<boolean>;
+  ifExists?: Resolvable<GitArtifactIfExists>;
 }): RlseStep => ({
   name: "push",
   run: (context) => {
-    const remote = options.remote ?? "origin";
-    const args = options?.setUpstream
-      ? ["push", "--set-upstream", remote, options.branch]
-      : ["push", remote, options.branch];
+    const branch = resolveOption(options.branch, context);
+    const remote = options.remote
+      ? resolveOption(options.remote, context)
+      : "origin";
+    const setUpstream = options.setUpstream
+      ? resolveOption(options.setUpstream, context)
+      : false;
+    const ifExists = options.ifExists
+      ? resolveOption(options.ifExists, context)
+      : "fail";
+    const args = setUpstream
+      ? ["push", "--set-upstream", remote, branch]
+      : ["push", remote, branch];
+    const remoteHead = context.dryRun
+      ? false
+      : getRemoteBranchHead(remote, branch, context.cwd);
+    const exists = Boolean(remoteHead);
+
+    if (exists && ifExists === "skip") {
+      consola.info(
+        `Branch ${branch} already exists on ${remote}; skipping push`,
+      );
+
+      return {
+        branch,
+        remote,
+        setUpstream,
+        dryRun: context.dryRun,
+        pushed: false,
+        skipped: true,
+        replaced: false,
+      };
+    }
+
+    if (exists && ifExists === "replace") {
+      args.splice(
+        1,
+        0,
+        `--force-with-lease=refs/heads/${branch}:${remoteHead}`,
+      );
+    }
 
     if (context.dryRun) {
       consola.info(`[dry-run] Skip git ${args.join(" ")}`);
 
       return {
-        branch: options.branch,
+        branch,
         remote,
-        setUpstream: options.setUpstream ?? false,
+        setUpstream,
         dryRun: true,
         pushed: false,
+        skipped: false,
+        replaced: false,
       };
     }
 
@@ -32,17 +74,37 @@ export const push = (options: {
         encoding: "utf8",
       },
       successCallback: (stdout) => {
-        consola.success(`Pushed to ${options.branch}`);
+        consola.success(`Pushed to ${branch}`);
         return stdout;
       },
     });
 
     return {
-      branch: options.branch,
+      branch,
       remote,
-      setUpstream: options.setUpstream ?? false,
+      setUpstream,
       dryRun: false,
       pushed: true,
+      skipped: false,
+      replaced: exists && ifExists === "replace",
     };
   },
 });
+
+const getRemoteBranchHead = (remote: string, branch: string, cwd: string) => {
+  const stdout = cmdFile(
+    "git",
+    ["ls-remote", "--exit-code", "--heads", remote, branch],
+    {
+      execOptions: {
+        cwd,
+        stdio: "pipe",
+        encoding: "utf8",
+      },
+      errorCallback: () => "",
+      silentError: true,
+    },
+  );
+
+  return stdout.trim().split(/\s+/)[0];
+};

--- a/packages/core/src/steps/git/pushTag.ts
+++ b/packages/core/src/steps/git/pushTag.ts
@@ -33,12 +33,7 @@ export const pushTag = (options: {
         dryRun: context.dryRun,
         pushed: false,
         skipped: true,
-        replaced: false,
       };
-    }
-
-    if (exists && ifExists === "replace") {
-      args.splice(1, 0, `--force-with-lease=refs/tags/${tag}:${remoteHead}`);
     }
 
     if (context.dryRun) {
@@ -50,7 +45,6 @@ export const pushTag = (options: {
         dryRun: true,
         pushed: false,
         skipped: false,
-        replaced: false,
       };
     }
 
@@ -71,7 +65,6 @@ export const pushTag = (options: {
       dryRun: false,
       pushed: true,
       skipped: false,
-      replaced: exists && ifExists === "replace",
     };
   },
   rollback: (context, result) => {

--- a/packages/core/src/steps/git/pushTag.ts
+++ b/packages/core/src/steps/git/pushTag.ts
@@ -2,10 +2,12 @@ import consola from "consola";
 import type { RlseStep } from "../../flow/types";
 import { cmdFile } from "../../utils/cmd";
 import { resolveOption, type Resolvable } from "../resolveOption";
+import type { GitArtifactIfExists } from "./releaseArtifacts";
 
 export const pushTag = (options: {
   tag: Resolvable<string>;
   remote?: Resolvable<string>;
+  ifExists?: Resolvable<GitArtifactIfExists>;
 }): RlseStep => ({
   name: "pushTag",
   run: (context) => {
@@ -13,7 +15,31 @@ export const pushTag = (options: {
     const remote = options.remote
       ? resolveOption(options.remote, context)
       : "origin";
+    const ifExists = options.ifExists
+      ? resolveOption(options.ifExists, context)
+      : "fail";
     const args = ["push", remote, `refs/tags/${tag}`];
+    const remoteHead = context.dryRun
+      ? false
+      : getRemoteTagHead(remote, tag, context.cwd);
+    const exists = Boolean(remoteHead);
+
+    if (exists && ifExists === "skip") {
+      consola.info(`Tag ${tag} already exists on ${remote}; skipping push`);
+
+      return {
+        tag,
+        remote,
+        dryRun: context.dryRun,
+        pushed: false,
+        skipped: true,
+        replaced: false,
+      };
+    }
+
+    if (exists && ifExists === "replace") {
+      args.splice(1, 0, `--force-with-lease=refs/tags/${tag}:${remoteHead}`);
+    }
 
     if (context.dryRun) {
       consola.info(`[dry-run] Skip git ${args.join(" ")}`);
@@ -23,6 +49,8 @@ export const pushTag = (options: {
         remote,
         dryRun: true,
         pushed: false,
+        skipped: false,
+        replaced: false,
       };
     }
 
@@ -42,6 +70,8 @@ export const pushTag = (options: {
       remote,
       dryRun: false,
       pushed: true,
+      skipped: false,
+      replaced: exists && ifExists === "replace",
     };
   },
   rollback: (context, result) => {
@@ -75,4 +105,22 @@ const isPushTagResult = (
     "pushed" in value &&
     typeof value.pushed === "boolean"
   );
+};
+
+const getRemoteTagHead = (remote: string, tag: string, cwd: string) => {
+  const stdout = cmdFile(
+    "git",
+    ["ls-remote", "--exit-code", "--refs", "--tags", remote, tag],
+    {
+      execOptions: {
+        cwd,
+        stdio: "pipe",
+        encoding: "utf8",
+      },
+      errorCallback: () => "",
+      silentError: true,
+    },
+  );
+
+  return stdout.trim().split(/\s+/)[0];
 };

--- a/packages/core/src/steps/git/releaseArtifacts.ts
+++ b/packages/core/src/steps/git/releaseArtifacts.ts
@@ -1,7 +1,7 @@
 import type { RlseContext } from "../../flow/types";
 import { resolveOption, type Resolvable } from "../resolveOption";
 
-export type GitArtifactIfExists = "fail" | "skip" | "replace";
+export type GitArtifactIfExists = "fail" | "skip";
 
 export const env = (
   names: string | string[],

--- a/packages/core/src/steps/git/releaseArtifacts.ts
+++ b/packages/core/src/steps/git/releaseArtifacts.ts
@@ -1,0 +1,49 @@
+import type { RlseContext } from "../../flow/types";
+import { resolveOption, type Resolvable } from "../resolveOption";
+
+export type GitArtifactIfExists = "fail" | "skip" | "replace";
+
+export const env = (
+  names: string | string[],
+  options?: {
+    fallback?: string;
+    separator?: string;
+  },
+) => {
+  const values = (Array.isArray(names) ? names : [names])
+    .map((name) => process.env[name])
+    .filter((value): value is string => Boolean(value));
+
+  if (!values.length) {
+    return options?.fallback;
+  }
+
+  return values.join(options?.separator ?? "-");
+};
+
+export const releaseBranchName = (options: {
+  version: Resolvable<string>;
+  prefix?: Resolvable<string>;
+  suffix?: Resolvable<string | false | undefined>;
+  separator?: Resolvable<string>;
+}) => {
+  return (context: RlseContext) => {
+    const prefix = options.prefix
+      ? resolveOption(options.prefix, context)
+      : "release";
+    const version = resolveOption(options.version, context);
+    const suffix = options.suffix
+      ? resolveOption(options.suffix, context)
+      : undefined;
+    const separator = options.separator
+      ? resolveOption(options.separator, context)
+      : "/";
+    const name = `${prefix}${separator}${version}`;
+
+    if (!suffix) {
+      return name;
+    }
+
+    return `${name}-${suffix}`;
+  };
+};

--- a/packages/core/src/steps/git/releaseArtifacts.ts
+++ b/packages/core/src/steps/git/releaseArtifacts.ts
@@ -28,19 +28,22 @@ export const releaseBranchName = (options: {
   separator?: Resolvable<string>;
 }) => {
   return (context: RlseContext) => {
-    const prefix = options.prefix
-      ? resolveOption(options.prefix, context)
-      : "release";
+    const prefix =
+      options.prefix !== undefined
+        ? resolveOption(options.prefix, context)
+        : "release";
     const version = resolveOption(options.version, context);
-    const suffix = options.suffix
-      ? resolveOption(options.suffix, context)
-      : undefined;
-    const separator = options.separator
-      ? resolveOption(options.separator, context)
-      : "/";
+    const suffix =
+      options.suffix !== undefined
+        ? resolveOption(options.suffix, context)
+        : undefined;
+    const separator =
+      options.separator !== undefined
+        ? resolveOption(options.separator, context)
+        : "/";
     const name = `${prefix}${separator}${version}`;
 
-    if (!suffix) {
+    if (suffix === false || suffix === undefined) {
       return name;
     }
 

--- a/packages/core/src/steps/git/tag.ts
+++ b/packages/core/src/steps/git/tag.ts
@@ -30,7 +30,6 @@ export const tag = (options: {
         dryRun: context.dryRun,
         tagged: false,
         skipped: true,
-        replaced: false,
       };
     }
 
@@ -43,17 +42,7 @@ export const tag = (options: {
         dryRun: true,
         tagged: false,
         skipped: false,
-        replaced: false,
       };
-    }
-
-    if (exists && ifExists === "replace") {
-      cmdFile("git", ["tag", "-d", name], {
-        execOptions: {
-          cwd: context.cwd,
-          encoding: "utf8",
-        },
-      });
     }
 
     cmdFile("git", args, {
@@ -73,7 +62,6 @@ export const tag = (options: {
       dryRun: false,
       tagged: true,
       skipped: false,
-      replaced: exists && ifExists === "replace",
     };
   },
   rollback: (context, result) => {

--- a/packages/core/src/steps/git/tag.ts
+++ b/packages/core/src/steps/git/tag.ts
@@ -2,10 +2,12 @@ import consola from "consola";
 import type { RlseStep } from "../../flow/types";
 import { cmdFile } from "../../utils/cmd";
 import { resolveOption, type Resolvable } from "../resolveOption";
+import type { GitArtifactIfExists } from "./releaseArtifacts";
 
 export const tag = (options: {
   name: Resolvable<string>;
   message?: Resolvable<string>;
+  ifExists?: Resolvable<GitArtifactIfExists>;
 }): RlseStep => ({
   name: "tag",
   run: (context) => {
@@ -13,7 +15,24 @@ export const tag = (options: {
     const message = options.message
       ? resolveOption(options.message, context)
       : undefined;
+    const ifExists = options.ifExists
+      ? resolveOption(options.ifExists, context)
+      : "fail";
     const args = message ? ["tag", "-a", name, "-m", message] : ["tag", name];
+    const exists = tagExists(name, context.cwd);
+
+    if (exists && ifExists === "skip") {
+      consola.info(`Tag ${name} already exists; skipping`);
+
+      return {
+        name,
+        message,
+        dryRun: context.dryRun,
+        tagged: false,
+        skipped: true,
+        replaced: false,
+      };
+    }
 
     if (context.dryRun) {
       consola.info(`[dry-run] Skip git ${args.join(" ")}`);
@@ -23,7 +42,18 @@ export const tag = (options: {
         message,
         dryRun: true,
         tagged: false,
+        skipped: false,
+        replaced: false,
       };
+    }
+
+    if (exists && ifExists === "replace") {
+      cmdFile("git", ["tag", "-d", name], {
+        execOptions: {
+          cwd: context.cwd,
+          encoding: "utf8",
+        },
+      });
     }
 
     cmdFile("git", args, {
@@ -42,6 +72,8 @@ export const tag = (options: {
       message,
       dryRun: false,
       tagged: true,
+      skipped: false,
+      replaced: exists && ifExists === "replace",
     };
   },
   rollback: (context, result) => {
@@ -68,5 +100,19 @@ const isTagResult = (
     typeof value.name === "string" &&
     "tagged" in value &&
     typeof value.tagged === "boolean"
+  );
+};
+
+const tagExists = (name: string, cwd: string) => {
+  return Boolean(
+    cmdFile("git", ["rev-parse", "--verify", `refs/tags/${name}`], {
+      execOptions: {
+        cwd,
+        stdio: "pipe",
+        encoding: "utf8",
+      },
+      errorCallback: () => "",
+      silentError: true,
+    }),
   );
 };

--- a/packages/core/src/steps/index.ts
+++ b/packages/core/src/steps/index.ts
@@ -9,6 +9,7 @@ export * from "./git/configureGit";
 export * from "./git/createReleaseBranch";
 export * from "./git/push";
 export * from "./git/pushTag";
+export * from "./git/releaseArtifacts";
 export * from "./git/stageFiles";
 export * from "./git/tag";
 export * from "./package/resolvePackage";

--- a/packages/core/test/config-version.test.mjs
+++ b/packages/core/test/config-version.test.mjs
@@ -598,7 +598,6 @@ test("skips pushing git tags during dry-run", async () => {
     dryRun: true,
     pushed: false,
     skipped: false,
-    replaced: false,
   });
 });
 
@@ -671,7 +670,6 @@ test("skips pushing existing git tags when requested", async () => {
       dryRun: false,
       pushed: false,
       skipped: true,
-      replaced: false,
     });
   } finally {
     rmSync(projectDir, { recursive: true, force: true });

--- a/packages/core/test/config-version.test.mjs
+++ b/packages/core/test/config-version.test.mjs
@@ -640,6 +640,154 @@ test("builds rerunnable release branch names from environment variables", async 
   }
 });
 
+test("respects empty release branch name options", async () => {
+  const { runFlow, steps } = await import(publicApiPath);
+  const branch = steps.releaseBranchName({
+    version: "1.2.3",
+    prefix: "",
+    suffix: "",
+    separator: "",
+  });
+  const context = await runFlow([
+    {
+      name: "branchName",
+      run: (rlseContext) => branch(rlseContext),
+    },
+  ]);
+
+  assert.equal(context.results.findStep("branchName"), "1.2.3-");
+});
+
+test("skips existing local git tags when requested", async () => {
+  const projectDir = createTempProject();
+
+  try {
+    commitAll(projectDir);
+    execFileSync("git", ["tag", "v1.2.3"], {
+      cwd: projectDir,
+      stdio: "pipe",
+    });
+    const tagBefore = execFileSync("git", ["rev-parse", "refs/tags/v1.2.3"], {
+      cwd: projectDir,
+      encoding: "utf8",
+    }).trim();
+
+    const { runFlow, steps } = await import(publicApiPath);
+    const context = await runFlow(
+      [steps.tag({ name: "v1.2.3", ifExists: "skip" })],
+      { cwd: projectDir },
+    );
+    const tagAfter = execFileSync("git", ["rev-parse", "refs/tags/v1.2.3"], {
+      cwd: projectDir,
+      encoding: "utf8",
+    }).trim();
+
+    assert.deepEqual(context.results.findStep("tag"), {
+      name: "v1.2.3",
+      message: undefined,
+      dryRun: false,
+      tagged: false,
+      skipped: true,
+    });
+    assert.equal(tagAfter, tagBefore);
+  } finally {
+    rmSync(projectDir, { recursive: true, force: true });
+  }
+});
+
+test("restores base branch after skipping an existing release branch", async () => {
+  const projectDir = createTempProject();
+
+  try {
+    commitAll(projectDir);
+    execFileSync("git", ["branch", "release/1.2.3"], {
+      cwd: projectDir,
+      stdio: "pipe",
+    });
+    const branchBefore = execFileSync(
+      "git",
+      ["rev-parse", "refs/heads/release/1.2.3"],
+      {
+        cwd: projectDir,
+        encoding: "utf8",
+      },
+    ).trim();
+
+    const { runFlow, steps } = await import(publicApiPath);
+    await assert.rejects(
+      () =>
+        runFlow(
+          [
+            steps.createReleaseBranch({
+              branch: "release/1.2.3",
+              ifExists: "skip",
+            }),
+            {
+              name: "fail",
+              run: () => {
+                throw new Error("fail after branch skip");
+              },
+            },
+          ],
+          { cwd: projectDir },
+        ),
+      /fail after branch skip/,
+    );
+
+    const currentBranch = execFileSync("git", ["branch", "--show-current"], {
+      cwd: projectDir,
+      encoding: "utf8",
+    }).trim();
+    const branchAfter = execFileSync(
+      "git",
+      ["rev-parse", "refs/heads/release/1.2.3"],
+      {
+        cwd: projectDir,
+        encoding: "utf8",
+      },
+    ).trim();
+
+    assert.equal(currentBranch, "main");
+    assert.equal(branchAfter, branchBefore);
+  } finally {
+    rmSync(projectDir, { recursive: true, force: true });
+  }
+});
+
+test("skips pushing existing git branches when requested", async () => {
+  const projectDir = createTempProject();
+  const remoteDir = mkdtempSync(path.join(tmpdir(), "rlse-remote-"));
+
+  try {
+    commitAll(projectDir);
+    execFileSync("git", ["init", "--bare", remoteDir], {
+      stdio: "pipe",
+    });
+    execFileSync("git", ["push", remoteDir, "main"], {
+      cwd: projectDir,
+      stdio: "pipe",
+    });
+
+    const { runFlow, steps } = await import(publicApiPath);
+    const context = await runFlow(
+      [steps.push({ branch: "main", remote: remoteDir, ifExists: "skip" })],
+      { cwd: projectDir },
+    );
+
+    assert.deepEqual(context.results.findStep("push"), {
+      branch: "main",
+      remote: remoteDir,
+      setUpstream: false,
+      dryRun: false,
+      pushed: false,
+      skipped: true,
+    });
+  } finally {
+    rmSync(projectDir, { recursive: true, force: true });
+    rmSync(remoteDir, { recursive: true, force: true });
+  }
+});
+
 test("skips pushing existing git tags when requested", async () => {
   const projectDir = createTempProject();
   const remoteDir = mkdtempSync(path.join(tmpdir(), "rlse-remote-"));

--- a/packages/core/test/config-version.test.mjs
+++ b/packages/core/test/config-version.test.mjs
@@ -597,7 +597,86 @@ test("skips pushing git tags during dry-run", async () => {
     remote: "origin",
     dryRun: true,
     pushed: false,
+    skipped: false,
+    replaced: false,
   });
+});
+
+test("builds rerunnable release branch names from environment variables", async () => {
+  const previousRunId = process.env.GITHUB_RUN_ID;
+  const previousRunAttempt = process.env.GITHUB_RUN_ATTEMPT;
+
+  try {
+    process.env.GITHUB_RUN_ID = "12345";
+    process.env.GITHUB_RUN_ATTEMPT = "2";
+
+    const { runFlow, steps } = await import(publicApiPath);
+    const branch = steps.releaseBranchName({
+      version: "1.2.3",
+      suffix: steps.env(["GITHUB_RUN_ID", "GITHUB_RUN_ATTEMPT"]),
+    });
+    const context = await runFlow([
+      {
+        name: "branchName",
+        run: (rlseContext) => branch(rlseContext),
+      },
+    ]);
+
+    assert.equal(
+      context.results.findStep("branchName"),
+      "release/1.2.3-12345-2",
+    );
+  } finally {
+    if (previousRunId === undefined) {
+      delete process.env.GITHUB_RUN_ID;
+    } else {
+      process.env.GITHUB_RUN_ID = previousRunId;
+    }
+
+    if (previousRunAttempt === undefined) {
+      delete process.env.GITHUB_RUN_ATTEMPT;
+    } else {
+      process.env.GITHUB_RUN_ATTEMPT = previousRunAttempt;
+    }
+  }
+});
+
+test("skips pushing existing git tags when requested", async () => {
+  const projectDir = createTempProject();
+  const remoteDir = mkdtempSync(path.join(tmpdir(), "rlse-remote-"));
+
+  try {
+    commitAll(projectDir);
+    execFileSync("git", ["init", "--bare", remoteDir], {
+      stdio: "pipe",
+    });
+    execFileSync("git", ["tag", "v1.2.3"], {
+      cwd: projectDir,
+      stdio: "pipe",
+    });
+    execFileSync("git", ["push", remoteDir, "refs/tags/v1.2.3"], {
+      cwd: projectDir,
+      stdio: "pipe",
+    });
+
+    const { runFlow, steps } = await import(publicApiPath);
+    const context = await runFlow(
+      [steps.pushTag({ tag: "v1.2.3", remote: remoteDir, ifExists: "skip" })],
+      { cwd: projectDir },
+    );
+
+    assert.deepEqual(context.results.findStep("pushTag"), {
+      tag: "v1.2.3",
+      remote: remoteDir,
+      dryRun: false,
+      pushed: false,
+      skipped: true,
+      replaced: false,
+    });
+  } finally {
+    rmSync(projectDir, { recursive: true, force: true });
+    rmSync(remoteDir, { recursive: true, force: true });
+  }
 });
 
 test("skips github release creation during dry-run", async () => {


### PR DESCRIPTION
## Summary
- add releaseBranchName and env helpers for deterministic release branch names
- add retry-aware ifExists: fail | skip handling to release branch, tag, branch push, and tag push steps
- update typed step results, docs, and tests for skipped git artifacts

## Tests
- pnpm -C packages/core test
- pnpm -C packages/core format:check
- pnpm -C packages/core lint

Fixes #36