### PR TITLE
Design structured flow error handling

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -282,6 +282,10 @@ export default defineConfig([
 
 Programmatic consumers can inspect the flow-level failure.
 
+`runFlow()` wraps step failures in `RlseFlowError`. To inspect the original
+thrown value, read `error.failed.error`. For steps that throw `RlseStepError`,
+structured partial data is available at `error.failed.partialResult`.
+
 ```ts
 import { RlseFlowError, runFlow } from "rlse.ts";
 
@@ -303,6 +307,12 @@ try {
 their side effects were later rolled back. `error.rollbacks` contains rollback
 attempts for completed steps that define `rollback`; rollback failures are
 recorded without replacing the original step failure.
+
+`partialResult` is intended for reporting and programmatic recovery. Avoid
+storing secrets or large payloads in it, because CLI output and logs may display
+the value. For `steps.parallel()`, task failures are exposed as a partial
+parallel result on `error.failed.partialResult`; the nested `AggregateError` is
+available as the `cause` of the failed `RlseStepError`.
 
 CLI arguments can be declared with Zod in config and used when building the flow.
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -148,7 +148,8 @@ fixing git access or push the created commit manually.
 ### API
 
 Rlse exports `defineConfig`, `presets`, `steps`, `runFlow`, `RlseFlowError`,
-`RlseStepError`, and `z`.
+`RlseStepError`, `RlseConfigError`, `RlseCliError`, and `z`. It also exports
+the public flow, result, parallel, and rollback types used by these APIs.
 
 #### Presets
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -147,7 +147,8 @@ fixing git access or push the created commit manually.
 
 ### API
 
-Rlse exports `defineConfig`, `presets`, `steps`, `runFlow`, and `z`.
+Rlse exports `defineConfig`, `presets`, `steps`, `runFlow`, `RlseFlowError`,
+`RlseStepError`, and `z`.
 
 #### Presets
 
@@ -237,6 +238,70 @@ Parallel task name lists are recorded in completion order. On failure, only
 successful tasks are rolled back, in reverse completion order.
 
 Custom steps can be added with `(context) => { ... }`.
+
+#### Error Handling
+
+When a step fails, `runFlow()` rolls back completed steps in reverse order and
+then throws `RlseFlowError`. The failed step itself is not rolled back because it
+did not produce a successful result. If a failed step needs to clean up its own
+partial side effects, do that inside `run()` before throwing.
+
+Use `RlseStepError` when a step can expose structured partial results on
+failure.
+
+```ts filename=rlse.config.ts
+import { defineConfig, RlseStepError } from "rlse.ts";
+
+export default defineConfig([
+  {
+    name: "uploadAssets",
+    async run() {
+      const uploaded: string[] = [];
+
+      try {
+        uploaded.push(await uploadFile("dist/index.js"));
+        uploaded.push(await uploadFile("dist/style.css"));
+        await uploadFile("dist/missing-file.js");
+
+        return { uploaded };
+      } catch (error) {
+        await Promise.allSettled(
+          uploaded.map((asset) => deleteUploadedFile(asset)),
+        );
+
+        throw new RlseStepError("Failed to upload assets", {
+          cause: error,
+          partialResult: { uploaded },
+        });
+      }
+    },
+  },
+]);
+```
+
+Programmatic consumers can inspect the flow-level failure.
+
+```ts
+import { RlseFlowError, runFlow } from "rlse.ts";
+
+try {
+  await runFlow(flow);
+} catch (error) {
+  if (error instanceof RlseFlowError) {
+    console.error(error.failed.step);
+    console.error(error.failed.error);
+    console.info(error.failed.partialResult);
+    console.info(error.succeeded.findStep("resolvePackage"));
+    console.info(error.rollbacks);
+    console.info(error.rollbackFailures);
+  }
+}
+```
+
+`error.succeeded` contains steps whose `run()` completed successfully, even if
+their side effects were later rolled back. `error.rollbacks` contains rollback
+attempts for completed steps that define `rollback`; rollback failures are
+recorded without replacing the original step failure.
 
 CLI arguments can be declared with Zod in config and used when building the flow.
 

--- a/packages/core/src/action/releaseAction.ts
+++ b/packages/core/src/action/releaseAction.ts
@@ -1,5 +1,6 @@
 import process from "node:process";
 import consola from "consola";
+import { RlseFlowError } from "../flow/errors";
 import { runFlow } from "../flow/runFlow";
 import type { RlseConfig } from "../types/RlseConfig";
 import { parseFlowSchema, parseReleaseSchema } from "../validation/validation";
@@ -14,7 +15,7 @@ export const releaseAction = async (
     const flow = resolveFlow(config, args);
     await runFlow(parseFlowSchema(flow), initialContext);
   } catch (error) {
-    consola.error(error);
+    logReleaseError(error);
     process.exit(1);
   }
 };
@@ -30,4 +31,37 @@ const resolveFlow = (
   return config.flow({
     args: config.args.parse(args),
   });
+};
+
+const logReleaseError = (error: unknown) => {
+  if (!(error instanceof RlseFlowError)) {
+    consola.error(error);
+    return;
+  }
+
+  consola.error(error.message);
+  logErrorCause("Cause", error.failed.error);
+
+  if (error.failed.partialResult !== undefined) {
+    consola.info("Partial result", error.failed.partialResult);
+  }
+
+  for (const rollback of error.rollbackFailures) {
+    consola.error(`Rollback failed at ${rollback.step}`);
+    logErrorCause("Rollback cause", rollback.error);
+  }
+};
+
+const logErrorCause = (label: string, error: unknown) => {
+  if (error instanceof AggregateError) {
+    consola.error(`${label}: ${error.message}`);
+
+    for (const nestedError of error.errors) {
+      logErrorCause("Nested cause", nestedError);
+    }
+
+    return;
+  }
+
+  consola.error(label, error);
 };

--- a/packages/core/src/bin.ts
+++ b/packages/core/src/bin.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import packageJson from "../package.json";
 import { releaseAction } from "./action/releaseAction";
 import { loadRlseConfig } from "./config/loadRlseConfig";
+import { RlseCliError } from "./flow/errors";
 import type { RlseConfig } from "./types/RlseConfig";
 import { parseReleaseSchema } from "./validation/validation";
 
@@ -70,7 +71,7 @@ const assertNotReservedArgName = (name: string) => {
     return;
   }
 
-  throw new Error(
+  throw new RlseCliError(
     `Unsupported CLI argument name: ${name}. --${flagName} is reserved by rlse.`,
   );
 };
@@ -100,7 +101,7 @@ const assertSupportedArgSchema = (name: string, schema: z.ZodTypeAny) => {
     return;
   }
 
-  throw new Error(
+  throw new RlseCliError(
     `Unsupported CLI argument schema for ${name}. Use z.string(), z.enum(), or z.boolean().`,
   );
 };

--- a/packages/core/src/config/loadRlseConfig.ts
+++ b/packages/core/src/config/loadRlseConfig.ts
@@ -14,6 +14,7 @@ import { dirname, extname, join, resolve } from "node:path";
 import { cwd } from "node:process";
 import { promisify } from "node:util";
 import consola from "consola";
+import { RlseConfigError } from "../flow/errors";
 import type { RlseConfig } from "../types/RlseConfig";
 
 const require = createRequire(import.meta.url);
@@ -46,12 +47,12 @@ export const loadRlseConfig = async () => {
           return JSON.parse(content) as RlseConfig;
         }
         default: {
-          throw new Error(`Unsupported file extension: ${ext}`);
+          throw new RlseConfigError(`Unsupported file extension: ${ext}`);
         }
       }
     }
   }
-  throw new Error("No configuration file found");
+  throw new RlseConfigError("No configuration file found");
 };
 
 const importTypeScriptConfig = async (filePath: string) => {

--- a/packages/core/src/flow/errors.ts
+++ b/packages/core/src/flow/errors.ts
@@ -1,7 +1,7 @@
 import type { RlseResults, RlseStepResult } from "./types";
 
 export class RlseStepError<TPartial = unknown> extends Error {
-  readonly cause: unknown;
+  declare readonly cause: unknown;
   readonly partialResult?: TPartial;
 
   constructor(
@@ -11,9 +11,8 @@ export class RlseStepError<TPartial = unknown> extends Error {
       partialResult?: TPartial;
     } = {},
   ) {
-    super(message);
+    super(message, createErrorOptions(options.cause));
     this.name = "RlseStepError";
-    this.cause = options.cause;
     this.partialResult = options.partialResult;
   }
 }
@@ -55,7 +54,7 @@ export type RlseStepRollbackFailed = {
 export type RlseRollbackResult = RlseStepRolledBack | RlseStepRollbackFailed;
 
 export class RlseFlowError<TPartial = unknown> extends Error {
-  readonly cause: unknown;
+  declare readonly cause: unknown;
   readonly failed: RlseStepFailed<TPartial>;
   readonly succeeded: RlseResults;
   readonly rollbacks: RlseRollbackResult[];
@@ -65,9 +64,10 @@ export class RlseFlowError<TPartial = unknown> extends Error {
     succeeded: RlseResults;
     rollbacks: RlseRollbackResult[];
   }) {
-    super(createFlowErrorMessage(options.failed));
+    super(createFlowErrorMessage(options.failed), {
+      cause: options.failed.error,
+    });
     this.name = "RlseFlowError";
-    this.cause = options.failed.error;
     this.failed = options.failed;
     this.succeeded = options.succeeded;
     this.rollbacks = options.rollbacks;
@@ -89,6 +89,14 @@ const createFlowErrorMessage = (failed: RlseStepFailed) => {
   }
 
   return `Release flow failed at ${failed.step}: ${causeMessage}`;
+};
+
+const createErrorOptions = (cause: unknown) => {
+  if (cause === undefined) {
+    return undefined;
+  }
+
+  return { cause };
 };
 
 const getErrorMessage = (error: unknown) => {

--- a/packages/core/src/flow/errors.ts
+++ b/packages/core/src/flow/errors.ts
@@ -18,6 +18,20 @@ export class RlseStepError<TPartial = unknown> extends Error {
   }
 }
 
+export class RlseConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RlseConfigError";
+  }
+}
+
+export class RlseCliError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RlseCliError";
+  }
+}
+
 export type RlseStepFailed<TPartial = unknown> = {
   step: string;
   status: "failed";

--- a/packages/core/src/flow/errors.ts
+++ b/packages/core/src/flow/errors.ts
@@ -1,0 +1,90 @@
+import type { RlseResults, RlseStepResult } from "./types";
+
+export class RlseStepError<TPartial = unknown> extends Error {
+  readonly cause: unknown;
+  readonly partialResult?: TPartial;
+
+  constructor(
+    message: string,
+    options: {
+      cause?: unknown;
+      partialResult?: TPartial;
+    } = {},
+  ) {
+    super(message);
+    this.name = "RlseStepError";
+    this.cause = options.cause;
+    this.partialResult = options.partialResult;
+  }
+}
+
+export type RlseStepFailed<TPartial = unknown> = {
+  step: string;
+  status: "failed";
+  error: unknown;
+  partialResult?: TPartial;
+};
+
+export type RlseStepRolledBack = {
+  step: string;
+  status: "rolledBack";
+  result: RlseStepResult;
+};
+
+export type RlseStepRollbackFailed = {
+  step: string;
+  status: "rollbackFailed";
+  result: RlseStepResult;
+  error: unknown;
+};
+
+export type RlseRollbackResult = RlseStepRolledBack | RlseStepRollbackFailed;
+
+export class RlseFlowError<TPartial = unknown> extends Error {
+  readonly cause: unknown;
+  readonly failed: RlseStepFailed<TPartial>;
+  readonly succeeded: RlseResults;
+  readonly rollbacks: RlseRollbackResult[];
+
+  constructor(options: {
+    failed: RlseStepFailed<TPartial>;
+    succeeded: RlseResults;
+    rollbacks: RlseRollbackResult[];
+  }) {
+    super(createFlowErrorMessage(options.failed));
+    this.name = "RlseFlowError";
+    this.cause = options.failed.error;
+    this.failed = options.failed;
+    this.succeeded = options.succeeded;
+    this.rollbacks = options.rollbacks;
+  }
+
+  get rollbackFailures() {
+    return this.rollbacks.filter(
+      (rollback): rollback is RlseStepRollbackFailed =>
+        rollback.status === "rollbackFailed",
+    );
+  }
+}
+
+const createFlowErrorMessage = (failed: RlseStepFailed) => {
+  const causeMessage = getErrorMessage(failed.error);
+
+  if (!causeMessage) {
+    return `Release flow failed at ${failed.step}`;
+  }
+
+  return `Release flow failed at ${failed.step}: ${causeMessage}`;
+};
+
+const getErrorMessage = (error: unknown) => {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  if (typeof error === "string") {
+    return error;
+  }
+
+  return undefined;
+};

--- a/packages/core/src/flow/runFlow.ts
+++ b/packages/core/src/flow/runFlow.ts
@@ -5,6 +5,12 @@ import type {
   RlseStep,
   RlseStepResult,
 } from "./types";
+import {
+  RlseFlowError,
+  RlseStepError,
+  type RlseRollbackResult,
+  type RlseStepFailed,
+} from "./errors";
 
 const normalizeStep = (step: RlseFlowStep): RlseStep => {
   if (typeof step === "function") {
@@ -49,21 +55,66 @@ export const runFlow = async (
   };
   const completedSteps: { step: RlseStep; result: RlseStepResult }[] = [];
 
-  try {
-    for (const flowStep of flow) {
-      const step = normalizeStep(flowStep);
+  for (const flowStep of flow) {
+    const step = normalizeStep(flowStep);
+
+    try {
       const value = await step.run(context);
       const result = { step: step.name, value };
       context.results.push(result);
       completedSteps.push({ step, result });
-    }
-  } catch (error) {
-    for (const { step, result } of completedSteps.reverse()) {
-      await step.rollback?.(context, result);
-    }
+    } catch (error) {
+      const rollbacks = await rollbackCompletedSteps(context, completedSteps);
 
-    throw error;
+      throw new RlseFlowError({
+        failed: createFailedStepResult(step.name, error),
+        succeeded: context.results,
+        rollbacks,
+      });
+    }
   }
 
   return context;
+};
+
+const createFailedStepResult = (
+  step: string,
+  error: unknown,
+): RlseStepFailed => ({
+  step,
+  status: "failed",
+  error,
+  partialResult:
+    error instanceof RlseStepError ? error.partialResult : undefined,
+});
+
+const rollbackCompletedSteps = async (
+  context: RlseContext,
+  completedSteps: { step: RlseStep; result: RlseStepResult }[],
+) => {
+  const rollbacks: RlseRollbackResult[] = [];
+
+  for (const { step, result } of [...completedSteps].reverse()) {
+    if (!step.rollback) {
+      continue;
+    }
+
+    try {
+      await step.rollback(context, result);
+      rollbacks.push({
+        step: step.name,
+        status: "rolledBack",
+        result,
+      });
+    } catch (error) {
+      rollbacks.push({
+        step: step.name,
+        status: "rollbackFailed",
+        result,
+        error,
+      });
+    }
+  }
+
+  return rollbacks;
 };

--- a/packages/core/src/flow/runFlow.ts
+++ b/packages/core/src/flow/runFlow.ts
@@ -29,7 +29,7 @@ const createResults = (results: RlseStepResult[] = []): RlseResults => {
       const result = results.findLast((item) => item.step === step);
 
       if (!result) {
-        throw new Error(`${step} result was not found`);
+        throw new RlseStepError(`${step} result was not found`);
       }
 
       return result.value;

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -1,6 +1,11 @@
 import { z } from "zod";
 import { defineConfig } from "./config/defineConfig";
-import { RlseFlowError, RlseStepError } from "./flow/errors";
+import {
+  RlseCliError,
+  RlseConfigError,
+  RlseFlowError,
+  RlseStepError,
+} from "./flow/errors";
 import { runFlow } from "./flow/runFlow";
 import type {
   RlseRollbackResult,
@@ -24,6 +29,8 @@ import * as steps from "./steps/index";
 export {
   defineConfig,
   presets,
+  RlseCliError,
+  RlseConfigError,
   RlseFlowError,
   RlseStepError,
   runFlow,

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -1,6 +1,13 @@
 import { z } from "zod";
 import { defineConfig } from "./config/defineConfig";
+import { RlseFlowError, RlseStepError } from "./flow/errors";
 import { runFlow } from "./flow/runFlow";
+import type {
+  RlseRollbackResult,
+  RlseStepFailed,
+  RlseStepRollbackFailed,
+  RlseStepRolledBack,
+} from "./flow/errors";
 import type {
   RlseContext,
   RlseFlowStep,
@@ -14,14 +21,26 @@ import type {
 import * as presets from "./presets/index";
 import * as steps from "./steps/index";
 
-export { defineConfig, presets, runFlow, steps, z };
+export {
+  defineConfig,
+  presets,
+  RlseFlowError,
+  RlseStepError,
+  runFlow,
+  steps,
+  z,
+};
 export type {
   RlseContext,
   RlseFlowStep,
   RlseKnownStepResults,
   RlseParallelResult,
   RlseParallelTaskResult,
+  RlseRollbackResult,
   RlseResults,
   RlseStep,
+  RlseStepFailed,
+  RlseStepRollbackFailed,
+  RlseStepRolledBack,
   RlseStepResult,
 };

--- a/packages/core/src/presets/index.ts
+++ b/packages/core/src/presets/index.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { RlseStepError } from "../flow/errors";
 import type { RlseContext, RlseFlowStep } from "../flow/types";
 import type { PackageJson } from "../steps/package/utils";
 import * as steps from "../steps/index";
@@ -110,7 +111,7 @@ const getResolvePackageResult = (context: RlseContext) => {
   const result = getLatestResult(context, "resolvePackage");
 
   if (!isResolvePackageResult(result)) {
-    throw new Error("resolvePackage result was not found");
+    throw new RlseStepError("resolvePackage result was not found");
   }
 
   return result;
@@ -120,7 +121,7 @@ const getResolvePublishedVersionResult = (context: RlseContext) => {
   const result = getLatestResult(context, "resolvePublishedVersion");
 
   if (!isResolvePublishedVersionResult(result)) {
-    throw new Error("resolvePublishedVersion result was not found");
+    throw new RlseStepError("resolvePublishedVersion result was not found");
   }
 
   return result;
@@ -130,7 +131,7 @@ const getCalculateNextSemverResult = (context: RlseContext) => {
   const result = getLatestResult(context, "calculateNextSemver");
 
   if (!isCalculateNextSemverResult(result)) {
-    throw new Error("calculateNextSemver result was not found");
+    throw new RlseStepError("calculateNextSemver result was not found");
   }
 
   return result;

--- a/packages/core/src/steps/git/checkCleanWorkingTree.ts
+++ b/packages/core/src/steps/git/checkCleanWorkingTree.ts
@@ -1,4 +1,5 @@
 import consola from "consola";
+import { RlseStepError } from "../../flow/errors";
 import type { RlseStep } from "../../flow/types";
 import { cmdFile } from "../../utils/cmd";
 
@@ -21,7 +22,16 @@ export const checkCleanWorkingTree = (options?: {
       .filter((entry) => !(options?.allowUntracked && entry.startsWith("??")));
 
     if (dirtyEntries.length) {
-      throw new Error(`Working tree is not clean:\n${dirtyEntries.join("\n")}`);
+      throw new RlseStepError(
+        `Working tree is not clean:\n${dirtyEntries.join("\n")}`,
+        {
+          partialResult: {
+            clean: false,
+            allowUntracked: options?.allowUntracked ?? false,
+            dirtyEntries,
+          },
+        },
+      );
     }
 
     consola.success("Working tree is clean");

--- a/packages/core/src/steps/git/commit.ts
+++ b/packages/core/src/steps/git/commit.ts
@@ -1,4 +1,5 @@
 import consola from "consola";
+import { RlseStepError } from "../../flow/errors";
 import type { RlseStep } from "../../flow/types";
 import { cmdFile } from "../../utils/cmd";
 import { getStagedFiles } from "./utils";
@@ -26,7 +27,15 @@ export const commit = (options: {
 
     if (!stagedFiles.length) {
       if (!options.skipIfNoChanges) {
-        throw new Error("No changes to commit");
+        throw new RlseStepError("No changes to commit", {
+          partialResult: {
+            message: options.message,
+            committed: false,
+            stagedFiles,
+            reason: "no_changes",
+            dryRun: false,
+          },
+        });
       }
 
       consola.info("No changes to commit");

--- a/packages/core/src/steps/git/configureGit.ts
+++ b/packages/core/src/steps/git/configureGit.ts
@@ -1,4 +1,5 @@
 import consola from "consola";
+import { RlseStepError } from "../../flow/errors";
 import type { RlseStep } from "../../flow/types";
 import { cmdFile } from "../../utils/cmd";
 
@@ -12,7 +13,7 @@ export const configureGitUser = (
   name: "configureGitUser",
   run: (context) => {
     if (!options.name && !options.email) {
-      throw new Error("Git user name or email must be provided");
+      throw new RlseStepError("Git user name or email must be provided");
     }
 
     if (context.dryRun) {

--- a/packages/core/src/steps/git/stageFiles.ts
+++ b/packages/core/src/steps/git/stageFiles.ts
@@ -1,4 +1,5 @@
 import consola from "consola";
+import { RlseStepError } from "../../flow/errors";
 import type { RlseStep } from "../../flow/types";
 import { cmdFile } from "../../utils/cmd";
 import { resolveOption, type Resolvable } from "../resolveOption";
@@ -11,7 +12,13 @@ export const stageFiles = (options: {
     const paths = resolveOption(options.paths, context);
 
     if (!paths.length) {
-      throw new Error("Files must be provided before stageFiles");
+      throw new RlseStepError("Files must be provided before stageFiles", {
+        partialResult: {
+          paths,
+          dryRun: context.dryRun,
+          staged: false,
+        },
+      });
     }
 
     if (context.dryRun) {

--- a/packages/core/src/steps/package/resolvePackage.ts
+++ b/packages/core/src/steps/package/resolvePackage.ts
@@ -1,3 +1,4 @@
+import { RlseStepError } from "../../flow/errors";
 import type { RlseStep } from "../../flow/types";
 import { findPackageJsonByName } from "../../utils/findPackageJsonByName";
 import { readPackageJson } from "./utils";
@@ -8,7 +9,11 @@ export const resolvePackage = (options: { name: string }): RlseStep => ({
     const packageJsonPath = await findPackageJsonByName(options.name);
 
     if (!packageJsonPath) {
-      throw new Error(`package.json for ${options.name} not found`);
+      throw new RlseStepError(`package.json for ${options.name} not found`, {
+        partialResult: {
+          packageName: options.name,
+        },
+      });
     }
 
     const packageJson = readPackageJson(packageJsonPath);

--- a/packages/core/src/steps/parallel.ts
+++ b/packages/core/src/steps/parallel.ts
@@ -1,4 +1,5 @@
 import consola from "consola";
+import { RlseStepError } from "../flow/errors";
 import type {
   RlseContext,
   RlseParallelResult,
@@ -154,7 +155,12 @@ export const parallel = (options: {
         context,
         completedTasks,
       );
-      throw createParallelError(options.name, taskFailures, rollbackFailures);
+      throw createParallelError(
+        options.name,
+        result,
+        taskFailures,
+        rollbackFailures,
+      );
     }
 
     consola.success(`Parallel step ${options.name} completed`);
@@ -207,7 +213,9 @@ const resolveConcurrency = (
   const resolvedConcurrency = concurrency ?? Math.max(taskCount, 1);
 
   if (!Number.isInteger(resolvedConcurrency) || resolvedConcurrency < 1) {
-    throw new Error("Parallel step concurrency must be a positive integer");
+    throw new RlseStepError(
+      "Parallel step concurrency must be a positive integer",
+    );
   }
 
   return Math.min(resolvedConcurrency, Math.max(taskCount, 1));
@@ -218,7 +226,9 @@ const validateTaskNames = (tasks: ParallelTask[]) => {
 
   for (const task of tasks) {
     if (names.has(task.name)) {
-      throw new Error(`Parallel task names must be unique: ${task.name}`);
+      throw new RlseStepError(
+        `Parallel task names must be unique: ${task.name}`,
+      );
     }
 
     names.add(task.name);
@@ -251,6 +261,7 @@ const rollbackCompletedTasks = async (
 
 const createParallelError = (
   stepName: string,
+  result: RlseParallelResult,
   taskFailures: { name: string; error: unknown }[],
   rollbackFailures: { name: string; error: unknown }[],
 ) => {
@@ -264,8 +275,14 @@ const createParallelError = (
     ? `; rollback failed for: ${rollbackNames}`
     : "";
 
-  return new AggregateError(
-    errors,
+  return new RlseStepError(
     `Parallel step ${stepName} failed for: ${taskNames}${rollbackMessage}`,
+    {
+      cause: new AggregateError(
+        errors,
+        `Parallel step ${stepName} failed for: ${taskNames}${rollbackMessage}`,
+      ),
+      partialResult: result,
+    },
   );
 };

--- a/packages/core/src/steps/publish/checkNpmPackageVersionAvailable.ts
+++ b/packages/core/src/steps/publish/checkNpmPackageVersionAvailable.ts
@@ -1,4 +1,5 @@
 import consola from "consola";
+import { RlseStepError } from "../../flow/errors";
 import type { RlseStep } from "../../flow/types";
 import { resolveNpmPackageVersion } from "./utils";
 import { resolveOption, type Resolvable } from "../resolveOption";
@@ -18,7 +19,16 @@ export const checkNpmPackageVersionAvailable = (options: {
     );
 
     if (publishedVersion === version) {
-      throw new Error(`${packageName}@${version} is already published`);
+      throw new RlseStepError(
+        `${packageName}@${version} is already published`,
+        {
+          partialResult: {
+            packageName,
+            version,
+            available: false,
+          },
+        },
+      );
     }
 
     consola.success(`${packageName}@${version} is available for publish`);

--- a/packages/core/src/steps/publish/verifyPublishedNpmPackage.ts
+++ b/packages/core/src/steps/publish/verifyPublishedNpmPackage.ts
@@ -1,4 +1,5 @@
 import consola from "consola";
+import { RlseStepError } from "../../flow/errors";
 import type { RlseStep } from "../../flow/types";
 import { cmdFile } from "../../utils/cmd";
 import { resolveOption, type Resolvable } from "../resolveOption";
@@ -30,8 +31,17 @@ export const verifyPublishedNpmPackage = (options: {
     );
 
     if (publishedVersion !== version) {
-      throw new Error(
+      throw new RlseStepError(
         `Expected ${packageName}@${version}, but registry returned ${publishedVersion}`,
+        {
+          partialResult: {
+            packageName,
+            version,
+            publishedVersion,
+            dryRun: false,
+            verified: false,
+          },
+        },
       );
     }
 
@@ -67,7 +77,7 @@ const resolvePublishedVersionWithRetry = (
         silentError: attempt < maxAttempts,
         errorCallback: (error) => {
           if (attempt === maxAttempts) {
-            throw new Error(error.message);
+            throw new RlseStepError(error.message, { cause: error });
           }
 
           consola.info(
@@ -85,7 +95,14 @@ const resolvePublishedVersionWithRetry = (
     }
   }
 
-  throw new Error(`Unable to verify ${packageName}@${version} on npm`);
+  throw new RlseStepError(`Unable to verify ${packageName}@${version} on npm`, {
+    partialResult: {
+      packageName,
+      version,
+      dryRun: false,
+      verified: false,
+    },
+  });
 };
 
 const wasNpmPublishSkipped = (

--- a/packages/core/src/steps/version/calculateNextVersion.ts
+++ b/packages/core/src/steps/version/calculateNextVersion.ts
@@ -1,4 +1,5 @@
 import { valid } from "semver";
+import { RlseStepError } from "../../flow/errors";
 import type { RlseStep } from "../../flow/types";
 import { resolveNextVersion } from "./utils";
 import type { VersionOptions } from "./types";
@@ -21,7 +22,14 @@ export const calculateNextSemver = (options: VersionOptions): RlseStep => ({
     });
 
     if (!nextVersion || !valid(nextVersion)) {
-      throw new Error(`Invalid version: ${nextVersion}`);
+      throw new RlseStepError(`Invalid version: ${nextVersion}`, {
+        partialResult: {
+          currentVersion,
+          nextVersion,
+          level: options.level,
+          pre,
+        },
+      });
     }
 
     return {

--- a/packages/core/src/steps/version/utils.ts
+++ b/packages/core/src/steps/version/utils.ts
@@ -1,4 +1,5 @@
 import { type ReleaseType, inc } from "semver";
+import { RlseStepError } from "../../flow/errors";
 import type { ReleaseLevel } from "../../types/RlseConfig";
 import type { PackageJson } from "../package/utils";
 import type { VersionOptions } from "./types";
@@ -16,7 +17,7 @@ export const resolveNextVersion = ({
 }) => {
   if (typeof options.version === "function") {
     if (!packageJson) {
-      throw new Error("Package JSON is required for version resolver");
+      throw new RlseStepError("Package JSON is required for version resolver");
     }
 
     return options.version({
@@ -38,7 +39,16 @@ export const resolveNextVersion = ({
     "beta",
   );
   if (!nextVersion) {
-    throw new Error(`Failed to increment version from ${currentVersion}`);
+    throw new RlseStepError(
+      `Failed to increment version from ${currentVersion}`,
+      {
+        partialResult: {
+          currentVersion,
+          level: options.level,
+          pre,
+        },
+      },
+    );
   }
 
   return nextVersion;
@@ -62,10 +72,10 @@ const getReleaseType = (level?: ReleaseLevel, pre = false): ReleaseType => {
       return "prerelease";
     }
     case "fix": {
-      throw new Error("Version is required for fix level");
+      throw new RlseStepError("Version is required for fix level");
     }
     case undefined: {
-      throw new Error(
+      throw new RlseStepError(
         "Release level is required when version is not configured",
       );
     }

--- a/packages/core/src/utils/cmd.ts
+++ b/packages/core/src/utils/cmd.ts
@@ -5,6 +5,7 @@ import {
   execSync,
 } from "node:child_process";
 import { consola } from "consola";
+import { RlseStepError } from "../flow/errors";
 
 type CallbackOptions = {
   successCallback?: (stdout: string) => string;
@@ -45,7 +46,7 @@ const handleCommandError = (
     return errorCallback(err);
   }
 
-  throw new Error(err.message);
+  throw new RlseStepError(err.message, { cause: err });
 };
 
 export const cmd: ShellCmd = (command, options) => {

--- a/packages/core/test/config-version.test.mjs
+++ b/packages/core/test/config-version.test.mjs
@@ -702,6 +702,10 @@ test("wraps failed steps with partial results in a flow error", async () => {
       assert.equal(error.failed.status, "failed");
       assert.ok(error.failed.error instanceof RlseStepError);
       assert.equal(error.failed.error.cause, cause);
+      assert.equal(Object.hasOwn(error, "cause"), true);
+      assert.equal(Object.hasOwn(error.failed.error, "cause"), true);
+      assert.equal(Object.keys(error).includes("cause"), false);
+      assert.equal(Object.keys(error.failed.error).includes("cause"), false);
       assert.deepEqual(error.failed.partialResult, {
         uploaded: ["dist/index.js"],
       });

--- a/packages/core/test/config-version.test.mjs
+++ b/packages/core/test/config-version.test.mjs
@@ -622,7 +622,9 @@ test("does not start queued parallel tasks after observing a failure", async () 
 });
 
 test("includes rollback failures in parallel task errors", async () => {
-  const { runFlow, steps } = await import(publicApiPath);
+  const { RlseFlowError, RlseStepError, runFlow, steps } = await import(
+    publicApiPath
+  );
 
   await assert.rejects(
     () =>
@@ -648,12 +650,21 @@ test("includes rollback failures in parallel task errors", async () => {
         }),
       ]),
     (error) => {
-      assert.ok(error instanceof AggregateError);
+      assert.ok(error instanceof RlseFlowError);
+      assert.equal(error.failed.step, "parallelRollbackFailure");
+      assert.ok(error.failed.error instanceof RlseStepError);
+      assert.ok(error.failed.error.cause instanceof AggregateError);
       assert.match(
-        error.message,
+        error.failed.error.cause.message,
         /Parallel step parallelRollbackFailure failed for: task:fail; rollback failed for: task:succeed/,
       );
-      assert.equal(error.errors.length, 2);
+      assert.equal(error.failed.error.cause.errors.length, 2);
+      assert.deepEqual(error.failed.partialResult.failedTaskNames, [
+        "task:fail",
+      ]);
+      assert.deepEqual(error.failed.partialResult.succeededTaskNames, [
+        "task:succeed",
+      ]);
 
       return true;
     },

--- a/packages/core/test/config-version.test.mjs
+++ b/packages/core/test/config-version.test.mjs
@@ -660,6 +660,120 @@ test("includes rollback failures in parallel task errors", async () => {
   );
 });
 
+test("wraps failed steps with partial results in a flow error", async () => {
+  const { RlseFlowError, RlseStepError, runFlow } = await import(publicApiPath);
+  const cause = new Error("upload unavailable");
+
+  await assert.rejects(
+    () =>
+      runFlow([
+        {
+          name: "prepare",
+          run: () => ({ prepared: true }),
+          rollback: () => {},
+        },
+        {
+          name: "uploadAssets",
+          run: () => {
+            throw new RlseStepError("Failed to upload assets", {
+              cause,
+              partialResult: {
+                uploaded: ["dist/index.js"],
+              },
+            });
+          },
+        },
+      ]),
+    (error) => {
+      assert.ok(error instanceof RlseFlowError);
+      assert.equal(error.name, "RlseFlowError");
+      assert.equal(error.failed.step, "uploadAssets");
+      assert.equal(error.failed.status, "failed");
+      assert.ok(error.failed.error instanceof RlseStepError);
+      assert.equal(error.failed.error.cause, cause);
+      assert.deepEqual(error.failed.partialResult, {
+        uploaded: ["dist/index.js"],
+      });
+      assert.deepEqual(error.succeeded, [
+        { step: "prepare", value: { prepared: true } },
+      ]);
+      assert.equal(error.succeeded.findStep("prepare").prepared, true);
+      assert.deepEqual(error.rollbacks, [
+        {
+          step: "prepare",
+          status: "rolledBack",
+          result: { step: "prepare", value: { prepared: true } },
+        },
+      ]);
+      assert.deepEqual(error.rollbackFailures, []);
+
+      return true;
+    },
+  );
+});
+
+test("records rollback failures without replacing the original failure", async () => {
+  const { RlseFlowError, runFlow } = await import(publicApiPath);
+  const flowFailure = new Error("publish failed");
+  const rollbackFailure = new Error("cleanup failed");
+
+  await assert.rejects(
+    () =>
+      runFlow([
+        {
+          name: "first",
+          run: () => ({ value: 1 }),
+          rollback: () => {},
+        },
+        {
+          name: "second",
+          run: () => ({ value: 2 }),
+          rollback: () => {
+            throw rollbackFailure;
+          },
+        },
+        {
+          name: "third",
+          run: () => {
+            throw flowFailure;
+          },
+        },
+      ]),
+    (error) => {
+      assert.ok(error instanceof RlseFlowError);
+      assert.equal(error.failed.step, "third");
+      assert.equal(error.failed.error, flowFailure);
+      assert.deepEqual(error.succeeded, [
+        { step: "first", value: { value: 1 } },
+        { step: "second", value: { value: 2 } },
+      ]);
+      assert.deepEqual(error.rollbacks, [
+        {
+          step: "second",
+          status: "rollbackFailed",
+          result: { step: "second", value: { value: 2 } },
+          error: rollbackFailure,
+        },
+        {
+          step: "first",
+          status: "rolledBack",
+          result: { step: "first", value: { value: 1 } },
+        },
+      ]);
+      assert.deepEqual(error.rollbackFailures, [
+        {
+          step: "second",
+          status: "rollbackFailed",
+          result: { step: "second", value: { value: 2 } },
+          error: rollbackFailure,
+        },
+      ]);
+
+      return true;
+    },
+  );
+});
+
 test("checks for a clean working tree", async () => {
   const projectDir = createTempProject();
 


### PR DESCRIPTION
## Summary
- add structured RlseStepError and RlseFlowError APIs for failed steps, partial results, and rollback outcomes
- wrap runFlow failures after rollback and expose succeeded results plus rollback failures
- convert core step/config/CLI errors to named rlse errors and integrate parallel partial failure reporting
- document the error model, compatibility notes, and add regression coverage

## Compatibility
- runFlow now wraps step failures in RlseFlowError; consumers that need the original thrown value should read error.failed.error
- steps.parallel failures are exposed through RlseFlowError.failed.error as RlseStepError, with the nested AggregateError available at error.failed.error.cause

## Tests
- pnpm -C packages/core test
- pnpm -C packages/core check