### PR TITLE
Colocate core tests with source files

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,7 +40,7 @@
   },
   "scripts": {
     "build": "tsup",
-    "test": "pnpm build && node --test ./test/*.test.mts",
+    "test": "pnpm build && node --test \"./src/**/*.test.mts\"",
     "lint": "pnpm exec oxlint --config ../../oxlint.config.ts .",
     "lint:fix": "pnpm exec oxlint --config ../../oxlint.config.ts --fix .",
     "format": "pnpm exec oxfmt --config ../../oxfmt.config.ts .",

--- a/packages/core/src/bin.test.mts
+++ b/packages/core/src/bin.test.mts
@@ -4,7 +4,7 @@ import { readFileSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import test from "node:test";
 
-import { cliPath, createTempProject, publicApiPath } from "./helpers.mts";
+import { cliPath, createTempProject, publicApiPath } from "./test-helpers.mts";
 
 void test("uses config-defined cli args in flow", () => {
   const projectDir = createTempProject();

--- a/packages/core/src/config/loadRlseConfig.test.mts
+++ b/packages/core/src/config/loadRlseConfig.test.mts
@@ -10,7 +10,7 @@ import {
 import path from "node:path";
 import test from "node:test";
 
-import { cliPath, createTempProject, packageRoot } from "./helpers.mts";
+import { cliPath, createTempProject, packageRoot } from "../test-helpers.mts";
 
 void test("loads TypeScript config", () => {
   const projectDir = createTempProject();

--- a/packages/core/src/flow/runFlow.test.mts
+++ b/packages/core/src/flow/runFlow.test.mts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { importPublicApi } from "./helpers.mts";
+import { importPublicApi } from "../test-helpers.mts";
 
 void test("collects flow step results", async () => {
   const { runFlow } = await importPublicApi();

--- a/packages/core/src/presets/index.test.mts
+++ b/packages/core/src/presets/index.test.mts
@@ -10,7 +10,7 @@ import {
 import path from "node:path";
 import test from "node:test";
 
-import { cliPath, createTempProject, publicApiPath } from "./helpers.mts";
+import { cliPath, createTempProject, publicApiPath } from "../test-helpers.mts";
 
 void test("uses npm release preset", () => {
   const projectDir = createTempProject();

--- a/packages/core/src/steps/changelog/updateChangelog.test.mts
+++ b/packages/core/src/steps/changelog/updateChangelog.test.mts
@@ -3,7 +3,7 @@ import { readFileSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import test from "node:test";
 
-import { createTempProject, importPublicApi } from "./helpers.mts";
+import { createTempProject, importPublicApi } from "../../test-helpers.mts";
 
 void test("updates changelog and rolls it back when a later step fails", async () => {
   const projectDir = createTempProject();

--- a/packages/core/src/steps/git/checkCleanWorkingTree.test.mts
+++ b/packages/core/src/steps/git/checkCleanWorkingTree.test.mts
@@ -2,7 +2,11 @@ import assert from "node:assert/strict";
 import { rmSync } from "node:fs";
 import test from "node:test";
 
-import { commitAll, createTempProject, importPublicApi } from "./helpers.mts";
+import {
+  commitAll,
+  createTempProject,
+  importPublicApi,
+} from "../../test-helpers.mts";
 
 void test("checks for a clean working tree", async () => {
   const projectDir = createTempProject();

--- a/packages/core/src/steps/git/createReleaseBranch.test.mts
+++ b/packages/core/src/steps/git/createReleaseBranch.test.mts
@@ -3,7 +3,11 @@ import { execFileSync } from "node:child_process";
 import { rmSync } from "node:fs";
 import test from "node:test";
 
-import { commitAll, createTempProject, importPublicApi } from "./helpers.mts";
+import {
+  commitAll,
+  createTempProject,
+  importPublicApi,
+} from "../../test-helpers.mts";
 
 void test("restores base branch after skipping an existing release branch", async () => {
   const projectDir = createTempProject();

--- a/packages/core/src/steps/git/push.test.mts
+++ b/packages/core/src/steps/git/push.test.mts
@@ -5,7 +5,11 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 
-import { commitAll, createTempProject, importPublicApi } from "./helpers.mts";
+import {
+  commitAll,
+  createTempProject,
+  importPublicApi,
+} from "../../test-helpers.mts";
 
 void test("skips pushing existing git branches when requested", async () => {
   const projectDir = createTempProject();

--- a/packages/core/src/steps/git/pushTag.test.mts
+++ b/packages/core/src/steps/git/pushTag.test.mts
@@ -5,7 +5,11 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 
-import { commitAll, createTempProject, importPublicApi } from "./helpers.mts";
+import {
+  commitAll,
+  createTempProject,
+  importPublicApi,
+} from "../../test-helpers.mts";
 
 void test("rolls back pushed git tags when a later step fails", async () => {
   const projectDir = createTempProject();

--- a/packages/core/src/steps/git/releaseArtifacts.test.mts
+++ b/packages/core/src/steps/git/releaseArtifacts.test.mts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { importPublicApi } from "./helpers.mts";
+import { importPublicApi } from "../../test-helpers.mts";
 
 void test("builds rerunnable release branch names from environment variables", async () => {
   const previousRunId = process.env.GITHUB_RUN_ID;

--- a/packages/core/src/steps/git/tag.test.mts
+++ b/packages/core/src/steps/git/tag.test.mts
@@ -3,7 +3,11 @@ import { execFileSync } from "node:child_process";
 import { rmSync } from "node:fs";
 import test from "node:test";
 
-import { commitAll, createTempProject, importPublicApi } from "./helpers.mts";
+import {
+  commitAll,
+  createTempProject,
+  importPublicApi,
+} from "../../test-helpers.mts";
 
 void test("rolls back created git tags when a later step fails", async () => {
   const projectDir = createTempProject();

--- a/packages/core/src/steps/github/githubRelease.test.mts
+++ b/packages/core/src/steps/github/githubRelease.test.mts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { importPublicApi } from "./helpers.mts";
+import { importPublicApi } from "../../test-helpers.mts";
 
 void test("skips github release creation during dry-run", async () => {
   const { runFlow, steps } = await importPublicApi();

--- a/packages/core/src/steps/parallel.test.mts
+++ b/packages/core/src/steps/parallel.test.mts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { importPublicApi } from "./helpers.mts";
+import { importPublicApi } from "../test-helpers.mts";
 
 void test("runs parallel tasks with aggregate results", async () => {
   const { runFlow, steps } = await importPublicApi();

--- a/packages/core/src/steps/publish/checkNpmPackageVersionAvailable.test.mts
+++ b/packages/core/src/steps/publish/checkNpmPackageVersionAvailable.test.mts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { importPublicApi } from "./helpers.mts";
+import { importPublicApi } from "../../test-helpers.mts";
 
 void test("checks npm package version availability without noisy command errors", async () => {
   const { runFlow, steps } = await importPublicApi();

--- a/packages/core/src/steps/publish/publish.test.mts
+++ b/packages/core/src/steps/publish/publish.test.mts
@@ -9,7 +9,7 @@ import {
 import path from "node:path";
 import test from "node:test";
 
-import { createTempProject, importPublicApi } from "./helpers.mts";
+import { createTempProject, importPublicApi } from "../../test-helpers.mts";
 
 void test("temporarily writes dry-run publish version and restores package json", async () => {
   const projectDir = createTempProject();

--- a/packages/core/src/steps/publish/verifyPublishedNpmPackage.test.mts
+++ b/packages/core/src/steps/publish/verifyPublishedNpmPackage.test.mts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { importPublicApi } from "./helpers.mts";
+import { importPublicApi } from "../../test-helpers.mts";
 
 void test("skips npm publish verification after dry-run publish", async () => {
   const { runFlow, steps } = await importPublicApi();

--- a/packages/core/src/steps/version/writePackageVersion.test.mts
+++ b/packages/core/src/steps/version/writePackageVersion.test.mts
@@ -4,7 +4,11 @@ import { readFileSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import test from "node:test";
 
-import { cliPath, createTempProject, publicApiPath } from "./helpers.mts";
+import {
+  cliPath,
+  createTempProject,
+  publicApiPath,
+} from "../../test-helpers.mts";
 
 void test("uses version generator from rlse config", () => {
   const projectDir = createTempProject();

--- a/packages/core/src/test-helpers.mts
+++ b/packages/core/src/test-helpers.mts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
-type PublicApi = typeof import("../src/main.ts");
+type PublicApi = typeof import("./main.ts");
 
 export const packageRoot = path.resolve(import.meta.dirname, "..");
 export const cliPath = path.join(packageRoot, "bin", "bin.js");


### PR DESCRIPTION
## Summary\n- move core .mts tests next to their corresponding source files\n- rename test files to match implementation file names\n- update the core test script to discover colocated src/**/*.test.mts files\n\n## Tests\n- pnpm p:core check\n- pnpm p:core test